### PR TITLE
3 add test mode procedure in flipper fap application

### DIFF
--- a/applications_user/uart_demo/tests/unit_tests/parse_msg_test.c
+++ b/applications_user/uart_demo/tests/unit_tests/parse_msg_test.c
@@ -5,111 +5,141 @@
 // Test 1: FPENDING message: +MSG: FPENDING
 static void parse_msg_with_fpending_test()
 {
-    FuriString* line = furi_string_alloc();
+    FuriString *line = furi_string_alloc();
     furi_string_set(line, "+MSG: FPENDING");
-    LoRaMsgResponse msg_response = {0};
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
 
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_fpending_test", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_fpending_test",
+                   "parse_msg_response() failed");
     }
     if (msg_response.is_pending != true) {
-        FURI_LOG_E("parse_msg_with_fpending_test", "FPENDING not detected");
+        FURI_LOG_E("parse_msg_with_fpending_test",
+                   "FPENDING not detected");
     }
-    
+
     furi_string_free(line);
 }
+
 // Test 2: Link margin and gateway_count message: +MSG: Link 20, 1
-static void parse_msg_with_link_test(){
-    FuriString* line = furi_string_alloc();
-    furi_string_set(line, "+MSG: Link 20, 1");
-    LoRaMsgResponse msg_response = {0};
+static void parse_msg_with_link_test()
+{
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+MSG: Link 20, 1\n");
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_link_test", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_link_test",
+                   "parse_msg_response() failed");
     }
     if (msg_response.margin != 20) {
-        FURI_LOG_E("parse_msg_with_link_test", "Incorrect margin: expected: 20, got: %d", msg_response.margin);
+        FURI_LOG_E("parse_msg_with_link_test",
+                   "Incorrect margin: expected: 20, got: %d",
+                   msg_response.margin);
     }
     if (msg_response.gateway_count != 1) {
-        FURI_LOG_E("parse_msg_with_link_test", "Incorrect gateway count: expected: 1, got: %d", msg_response.gateway_count);
+        FURI_LOG_E("parse_msg_with_link_test",
+                   "Incorrect gateway count: expected: 1, got: %d",
+                   msg_response.gateway_count);
     }
-    
+
     furi_string_free(line);
 }
 
 // Test 3: RXWIN message with RSSI and SNR : +MSG: RXWIN2, RSSI -106, SNR 4
-static void parse_msg_with_rxwin_test(){
-    FuriString* line = furi_string_alloc();
-    furi_string_set(line, "+MSG: RXWIN2, RSSI -106, SNR 4");
-    LoRaMsgResponse msg_response = {0};
+static void parse_msg_with_rxwin_test()
+{
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+MSG: RXWIN2, RSSI -106, SNR 4\n");
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
-    
+
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_rxwin_test", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_rxwin_test",
+                   "parse_msg_response() failed");
     }
     if (msg_response.rx_window != 2) {
-        FURI_LOG_E("parse_msg_with_rxwin_test", "Incorrect RXWIN: expected: 2, got: %d", msg_response.rx_window);
+        FURI_LOG_E("parse_msg_with_rxwin_test",
+                   "Incorrect RXWIN: expected: 2, got: %d",
+                   msg_response.rx_window);
     }
     if (msg_response.rssi != -106) {
-        FURI_LOG_E("parse_msg_with_rxwin_test", "Incorrect RSSI: expected: -106, got: %d", msg_response.rssi);
+        FURI_LOG_E("parse_msg_with_rxwin_test",
+                   "Incorrect RSSI: expected: -106, got: %d",
+                   msg_response.rssi);
     }
 
     if (msg_response.snr != 4) {
-        FURI_LOG_E("parse_msg_with_rxwin_test", "Incorrect SNR: expected: 4, got: %d", msg_response.snr);
+        FURI_LOG_E("parse_msg_with_rxwin_test",
+                   "Incorrect SNR: expected: 4, got: %d",
+                   msg_response.snr);
     }
-    
+
     furi_string_free(line);
 }
 
 // Test 4: ACK Received message of type : +MSG: ACK Received
 static void parse_msg_with_ack_received_test()
 {
-    FuriString* line = furi_string_alloc();
-    furi_string_set(line, "+MSG: ACK Received");
-    LoRaMsgResponse msg_response = {0};
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+MSG: ACK Received\n");
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_ack_received_test", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_ack_received_test",
+                   "parse_msg_response() failed");
     }
     if (msg_response.is_ack != true) {
-        FURI_LOG_E("parse_msg_with_ack_received_test", "Incorrect ACK status, expected: true, got: %s", msg_response.is_ack ? "true" : "false");
+        FURI_LOG_E("parse_msg_with_ack_received_test",
+                   "Incorrect ACK status, expected: true, got: %s",
+                   msg_response.is_ack ? "true" : "false");
     }
 
     furi_string_free(line);
 }
 
 // Test 5: Test parsing function with message of type : +MSG: PORT: 8; RX: "12345678"
-static void parse_msg_with_port_and_data(){
-    FuriString* line = furi_string_alloc();
-    furi_string_set(line, "+MSG: PORT: 8; RX: \"12345678\"");
-    LoRaMsgResponse msg_response = {0};
+static void parse_msg_with_port_and_data()
+{
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+MSG: PORT: 8; RX: \"12345678\"\n");
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
 
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_port_and_data", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_port_and_data",
+                   "parse_msg_response() failed");
     }
     if (strcmp(msg_response.data, "12345678") != 0) {
-        FURI_LOG_E("parse_msg_with_port_and_data", "Incorrect RX data: expected: 12345678, got: %s", msg_response.data);
+        FURI_LOG_E("parse_msg_with_port_and_data",
+                   "Incorrect RX data: expected: 12345678, got: %s",
+                   msg_response.data);
 
     }
     if (msg_response.port != 8) {
-        FURI_LOG_E("parse_msg_with_port_and_data", "Incorrect port: expected: 8, got: %d", msg_response.port);
+        FURI_LOG_E("parse_msg_with_port_and_data",
+                   "Incorrect port: expected: 8, got: %d",
+                   msg_response.port);
     }
-    
+
     furi_string_free(line);
 }
 
-static void parse_msg_with_multicast(){
-    FuriString* line = furi_string_alloc();
-    furi_string_set(line, "+MSG: MULTICAST");
-    LoRaMsgResponse msg_response = {0};
+static void parse_msg_with_multicast()
+{
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+MSG: MULTICAST\n");
+    LoRaMsgResponse msg_response = { 0 };
     int result = parse_msg_response(line, &msg_response);
     if (result != 0) {
-        FURI_LOG_E("parse_msg_with_multicast", "parse_msg_response() failed");
+        FURI_LOG_E("parse_msg_with_multicast",
+                   "parse_msg_response() failed");
     }
     if (msg_response.is_multicast != true) {
-        FURI_LOG_E("parse_msg_with_multicast", "Incorrect multicast status, expected: true, got: %s", msg_response.is_multicast ? "true" : "false");
+        FURI_LOG_E("parse_msg_with_multicast",
+                   "Incorrect multicast status, expected: true, got: %s",
+                   msg_response.is_multicast ? "true" : "false");
     }
 
     furi_string_free(line);
@@ -129,6 +159,3 @@ int parse_msg_test_suite()
     FURI_LOG_I("parse_msg_test_suite", "All Unit Tests passed");
     return 0;
 }
-
-
-

--- a/applications_user/uart_demo/tests/unit_tests/parsers_test.c
+++ b/applications_user/uart_demo/tests/unit_tests/parsers_test.c
@@ -2,7 +2,11 @@
 
 #include <furi.h>
 
-// Test 1: FPENDING message: +MSG: FPENDING
+/**
+ * Test case for parsing a FPENDING message.
+ * Input: "+MSG: FPENDING"
+ * Expected: msg_response.is_pending should be true.
+ */
 static void parse_msg_with_fpending_test()
 {
     FuriString *line = furi_string_alloc();
@@ -22,7 +26,11 @@ static void parse_msg_with_fpending_test()
     furi_string_free(line);
 }
 
-// Test 2: Link margin and gateway_count message: +MSG: Link 20, 1
+/**
+ * Test case for parsing a Link message with margin and gateway count.
+ * Input: "+MSG: Link 20, 1"
+ * Expected: msg_response.margin should be 20, msg_response.gateway_count should be 1.
+ */
 static void parse_msg_with_link_test()
 {
     FuriString *line = furi_string_alloc();
@@ -47,7 +55,11 @@ static void parse_msg_with_link_test()
     furi_string_free(line);
 }
 
-// Test 3: RXWIN message with RSSI and SNR : +MSG: RXWIN2, RSSI -106, SNR 4
+/**
+ * Test case for parsing an RXWIN message with RSSI and SNR values.
+ * Input: "+MSG: RXWIN2, RSSI -106, SNR 4"
+ * Expected: msg_response.rx_window should be 2, msg_response.rssi should be -106, msg_response.snr should be 4.
+ */
 static void parse_msg_with_rxwin_test()
 {
     FuriString *line = furi_string_alloc();
@@ -79,7 +91,11 @@ static void parse_msg_with_rxwin_test()
     furi_string_free(line);
 }
 
-// Test 4: ACK Received message of type : +MSG: ACK Received
+/**
+ * Test case for parsing an ACK Received message.
+ * Input: "+MSG: ACK Received"
+ * Expected: msg_response.is_ack should be true.
+ */
 static void parse_msg_with_ack_received_test()
 {
     FuriString *line = furi_string_alloc();
@@ -99,7 +115,11 @@ static void parse_msg_with_ack_received_test()
     furi_string_free(line);
 }
 
-// Test 5: Test parsing function with message of type : +MSG: PORT: 8; RX: "12345678"
+/**
+ * Test case for parsing a message containing port and RX data.
+ * Input: "+MSG: PORT: 8; RX: \"12345678\""
+ * Expected: msg_response.port should be 8, msg_response.data should be "12345678".
+ */
 static void parse_msg_with_port_and_data()
 {
     FuriString *line = furi_string_alloc();
@@ -115,7 +135,6 @@ static void parse_msg_with_port_and_data()
         FURI_LOG_E("parse_msg_with_port_and_data",
                    "Incorrect RX data: expected: 12345678, got: %s",
                    msg_response.data);
-
     }
     if (msg_response.port != 8) {
         FURI_LOG_E("parse_msg_with_port_and_data",
@@ -126,6 +145,11 @@ static void parse_msg_with_port_and_data()
     furi_string_free(line);
 }
 
+/**
+ * Test case for parsing a MULTICAST message.
+ * Input: "+MSG: MULTICAST"
+ * Expected: msg_response.is_multicast should be true.
+ */
 static void parse_msg_with_multicast()
 {
     FuriString *line = furi_string_alloc();
@@ -145,9 +169,31 @@ static void parse_msg_with_multicast()
     furi_string_free(line);
 }
 
+/**
+ * Test case for extracting raw data from an RX packet.
+ * Input: "+TEST: RX \"48656C6C6F20576F726C642021\""
+ * Expected: msg_response.data should be "48656C6C6F20576F726C642021".
+ */
+static void parse_data_rx_packet()
+{
+    FuriString *line = furi_string_alloc();
+    furi_string_set(line, "+TEST: RX \"48656C6C6F20576F726C642021\"\n");
+    LoRaMsgResponse rx_response = { 0 };
+    int result = parse_msg_response(line, &rx_response);
+    if (result != 0) {
+        FURI_LOG_E("parse_data_rx_response_test",
+                   "parse_rx_packet() failed");
+    }
+    if (strcmp(rx_response.data, "48656C6C6F20576F726C642021") != 0) {
+        FURI_LOG_E("parse_data_rx_response_test",
+                   "Incorrect RX data: expected: 12345678, got: %s",
+                   rx_response.data);
+    }
 
+    furi_string_free(line);
+}
 
-int parse_msg_test_suite()
+int parsers_test_suite()
 {
     parse_msg_with_fpending_test();
     parse_msg_with_link_test();
@@ -155,7 +201,8 @@ int parse_msg_test_suite()
     parse_msg_with_ack_received_test();
     parse_msg_with_port_and_data();
     parse_msg_with_multicast();
+    parse_data_rx_packet();
 
-    FURI_LOG_I("parse_msg_test_suite", "All Unit Tests passed");
+    FURI_LOG_I("parsers_test_suite", "All Unit Tests passed");
     return 0;
 }

--- a/applications_user/uart_demo/tests/unit_tests/unit_tests.c
+++ b/applications_user/uart_demo/tests/unit_tests/unit_tests.c
@@ -1,8 +1,9 @@
 #include "../test.h"
 #include "unit_tests.h"
 
-int run_unit_tests(void) {
+int run_unit_tests(void)
+{
     // Add your test suite calls here
-    parse_msg_test_suite();
+    parsers_test_suite();
     return 0;
 }

--- a/applications_user/uart_demo/tests/unit_tests/unit_tests.h
+++ b/applications_user/uart_demo/tests/unit_tests/unit_tests.h
@@ -1,6 +1,6 @@
 #ifndef UNIT_TESTS_H
 #define UNIT_TESTS_H
 
-int parse_msg_test_suite();
+int parsers_test_suite();
 int run_unit_tests(void);
 #endif

--- a/applications_user/uart_demo/uart_demo.c
+++ b/applications_user/uart_demo/uart_demo.c
@@ -41,71 +41,64 @@ static void otaa_join_procedure(void *context)
 {
     UartDemoApp *app = context;
     int join_attempts = 1;
-    
+
     // Loop until the device is joined to the network
-    while (!(app->lora_bitmask & JOINED)) {
+    while (app->current_state != JOINED) {
         FURI_LOG_I("OTAA_JOIN", "Attempting to join the network...");
         // Send the join command
-        uart_helper_send(app->uart_helper, "AT+JOIN_CMD\n", 9, JOIN_CMD);
+        uart_helper_send(app->uart_helper, "AT+JOIN_CMD\n", 13);
         furi_delay_ms(10000);
-        
-        if(app->lora_bitmask & JOINED) {
+
+        if (app->current_state == JOINED) {
             // Device is joined, break the loop
             break;
         }
 
         join_attempts++;
 
-        if(join_attempts > 3){
+        if (join_attempts > 3) {
             // If the device is not joined after 3 attempts, break the loop
             FURI_LOG_I("OTAA_JOIN", "Failed to join after 3 attempts");
             break;
         }
 
         FURI_LOG_I("OTAA_JOIN", "Join attempt %d", join_attempts);
-        
-    }
 
+    }
 }
 
 static void setup_lora_connexion(void *context)
 {
     UartDemoApp *app = context;
 
-    uart_helper_send(app->uart_helper, "AT+ID\n", 7, CONFIG_CMD);
+    uart_helper_send(app->uart_helper, "AT+ID\n", 7);
     furi_delay_ms(1000);
 
-    uart_helper_send(app->uart_helper, "AT+MODE=LWOTAA\n", 16,
-                     CONFIG_CMD);
+    uart_helper_send(app->uart_helper, "AT+MODE=LWOTAA\n", 16);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+DR=%d\n", dr);
-    uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            CONFIG_CMD);
+    uart_helper_send_string(app->uart_helper, app->send_cmd);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+POWER=%d\n", tx_power);
-    uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            CONFIG_CMD);
+    uart_helper_send_string(app->uart_helper, app->send_cmd);
     furi_delay_ms(1000);
 
-    uart_helper_send(app->uart_helper, "AT+ADR=ON\n", 11,
-                     CONFIG_CMD);
+    uart_helper_send(app->uart_helper, "AT+ADR=ON\n", 11);
     furi_delay_ms(1000);
 
-    uart_helper_send(app->uart_helper, "AT+CLASS=A\n", 12,
-                     CONFIG_CMD);
+    uart_helper_send(app->uart_helper, "AT+CLASS=A\n", 12);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+KEY=APPKEY,%s\n", APPKEY);
-    uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            CONFIG_CMD);
+    uart_helper_send_string(app->uart_helper, app->send_cmd);
     furi_delay_ms(1000);
 
-    // TODO : change because we need to pass to a specific callback
-    app->lora_bitmask |= CONFIG;
+    app->current_state = CONFIG;
 
 }
+
 // static void decode_data(char *data)
 // {
 //     // Decode the data received from the server
@@ -113,36 +106,41 @@ static void setup_lora_connexion(void *context)
 //     FURI_LOG_I("DECODE_DATA", "Data: %s", data);
 // }
 static void send_cmsg(UartDemoApp *app, const char *msg)
-{   
+{
     furi_string_printf(app->send_cmd, "AT+CMSG=%s\n", msg);
-    uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            CMSG_CMD);
+    uart_helper_send_string(app->uart_helper, app->send_cmd);
     furi_delay_ms(1000);
     DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
 }
 
-static void enter_test_mode(UartDemoApp *app)
+static void enter_test_mode(void *context)
 {
-    uart_helper_send(app->uart_helper, "AT+MODE=TEST\n", 10, CONFIG_CMD);
+    UartDemoApp *app = context;
+    app->current_state = CONFIG;
+    uart_helper_send(app->uart_helper, "AT+MODE=TEST\n", 14);
     furi_delay_ms(1000);
 }
-static void enter_rx_mode(UartDemoApp *app)
-{   
+
+static void enter_rx_mode(void *context)
+{
+    UartDemoApp *app = context;
+    app->current_state = CONFIG;
     enter_test_mode(app);
+    uart_helper_send(app->uart_helper, "AT+TEST=RXLRPKT\n", 17);
     furi_delay_ms(1000);
+    app->current_state = RX;
 }
 
 static void uart_demo_submenu_item_callback(void *context, uint32_t index)
 {
     UartDemoApp *app = context;
 
-    switch (index)
-    {
+    switch (index) {
     case 0:
         // Clear the submenu and add the default entries.
         uart_demo_submenu_add_default_entries(app->submenu, app);
         break;
-    case 1: 
+    case 1:
         setup_lora_connexion(app);
         otaa_join_procedure(app);
         break;
@@ -157,25 +155,12 @@ static void uart_demo_submenu_item_callback(void *context, uint32_t index)
     default:
         break;
     }
-    if (index == 0) {
-        // Clear the submenu and add the default entries.
-        uart_demo_submenu_add_default_entries(app->submenu, app);
-    } else if (index == 1) {
-        setup_lora_connexion(app);
-        otaa_join_procedure(app);
-    } else if (index == 2) {
-        // Send a confirmed message to the server.
-    
-    } else if (index == 3){
-        send_cmsg(app, "Hello World");
-    }
-    else {
-        // The item was received data.
-    }
 }
 
-int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
-    if (!line || !msg_response) return -1;
+int parse_msg_response(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    if (!line || !msg_response)
+        return -1;
 
     // Parse the line to extract the fields
     size_t index;
@@ -184,9 +169,8 @@ int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
     // Get delimiter `:` index
     index = furi_string_search_char(line, ':', 0);
     if (index == FURI_STRING_FAILURE) {
-        return -1; // No delimiter found
+        return -1;              // No delimiter found
     }
-    
     // Extract the right part of the line
     furi_string_right(line, index + 1); // Trim
 
@@ -198,31 +182,33 @@ int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
 
     index = furi_string_search_str(line, "Link ", 0);
     if (index != FURI_STRING_FAILURE) {
-        char* endptr;
-        const char* str_start = furi_string_get_cstr(line) + index + 5;
-        
+        char *endptr;
+        const char *str_start = furi_string_get_cstr(line) + index + 5;
+
         // Extract margin
-        msg_response->margin = (uint8_t)strtol(str_start, &endptr, 10);
-        
+        msg_response->margin = (uint8_t) strtol(str_start, &endptr, 10);
+
         // Extract gateway_count if there's a comma
         if (*endptr == ',') {
-            msg_response->gateway_count = (uint8_t)strtol(endptr + 1, NULL, 10);
+            msg_response->gateway_count =
+                (uint8_t) strtol(endptr + 1, NULL, 10);
         }
         return 0;
     }
 
     index = furi_string_search_str(line, "RXWIN", 0);
     if (index != FURI_STRING_FAILURE) {
-        msg_response->rx_window = (uint8_t)(furi_string_get_char(line, index + 5) - '0');
-        
-        char* endptr;
-        const char* str_start = furi_string_get_cstr(line) + index + 14;
-        
+        msg_response->rx_window =
+            (uint8_t) (furi_string_get_char(line, index + 5) - '0');
+
+        char *endptr;
+        const char *str_start = furi_string_get_cstr(line) + index + 14;
+
         // Extract RSSI value
-        msg_response->rssi = -(int8_t)strtol(str_start, &endptr, 10);
-        
+        msg_response->rssi = -(int8_t) strtol(str_start, &endptr, 10);
+
         // Extract SNR value
-        msg_response->snr = (int8_t)strtol(endptr + 6, NULL, 10);
+        msg_response->snr = (int8_t) strtol(endptr + 6, NULL, 10);
         return 0;
     }
 
@@ -240,18 +226,18 @@ int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
 
     index = furi_string_search_str(line, "PORT: ", 0);
     if (index != FURI_STRING_FAILURE) {
-        const char* str_start = furi_string_get_cstr(line) + index + 6;
-        msg_response->port = (uint8_t)strtol(str_start, NULL, 10);
+        const char *str_start = furi_string_get_cstr(line) + index + 6;
+        msg_response->port = (uint8_t) strtol(str_start, NULL, 10);
     }
 
     index = furi_string_search_str(line, "RX: ", 0);
     if (index != FURI_STRING_FAILURE) {
-        const char* data_start = furi_string_get_cstr(line) + index + 5; // Skip RX: "
+        const char *data_start = furi_string_get_cstr(line) + index + 5; // Skip RX: "
         strcpy(msg_response->data, data_start);
 
         size_t length = strlen(msg_response->data);
-        if (length > 0 && msg_response->data[length - 1] == '"') {
-            msg_response->data[length - 1] = '\0'; // Remove the trailing quote
+        if (length > 0 && msg_response->data[length - 2] == '"') {
+            msg_response->data[length - 2] = '\0'; // Remove the trailing quote
         }
         return 0;
     }
@@ -259,22 +245,63 @@ int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
     return 0;
 }
 
+static int parse_rx_response(FuriString *line,
+                             LoRaMsgResponse *rx_response)
+{
+    if (!line || !rx_response)
+        return -1;
+    // Parse the line to extract the fields
+    size_t index;
+    FURI_LOG_D("parse_rx_response", "%s", furi_string_get_cstr(line));
+
+    // Get delimiter `:` index
+    index = furi_string_search_char(line, ':', 0);
+    if (index == FURI_STRING_FAILURE) {
+        return -1;              // No delimiter found
+    }
+    // Extract the right part of the line
+    furi_string_right(line, index + 1); // Trim
+
+    index = furi_string_search_str(line, "RX", 0);
+    if (index != FURI_STRING_FAILURE) {
+        const char *data_start = furi_string_get_cstr(line) + index + 4; // Skip RX "
+        strcpy(rx_response->data, data_start);
+
+        size_t length = strlen(rx_response->data);
+        if (length > 0 && rx_response->data[length - 2] == '"') {
+            rx_response->data[length - 2] = '\0'; // Remove the trailing quote
+        }
+        return 0;
+    }
+
+    return 0;
+}
+
+
 void handle_msg_response(FuriString *line, void *context)
 {
     UartDemoApp *app = context;
     parse_msg_response(line, app->msg_response);
 }
+
+void handle_rx_response(FuriString *line, void *context)
+{
+    UartDemoApp *app = context;
+    parse_rx_response(line, app->msg_response);
+    DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
+}
+
 void handle_join_response(FuriString *line, void *context)
 {
-    FURI_LOG_I("handle_join_response", "%s",
-               furi_string_get_cstr(line));
+    FURI_LOG_I("handle_join_response", "%s", furi_string_get_cstr(line));
     UartDemoApp *app = context;
     if (furi_string_start_with(line, "+JOIN_CMD: Network joined")) {
-        app->lora_bitmask |= JOINED;
+        app->current_state = JOINED;
         FURI_LOG_I("handle_join_response", "Network joined");
         return;
-    } 
+    }
 }
+
 #ifdef DEMO_PROCESS_LINE
 void handle_default_response(FuriString *line, void *context)
 {
@@ -341,7 +368,7 @@ static UartDemoApp *uart_demo_app_alloc()
 
     // Allocate a string to store sendings commands
     app->send_cmd = furi_string_alloc();
-    app->lora_bitmask = 0;
+    app->current_state = INIT;
 
     app->msg_response = malloc(sizeof(LoRaMsgResponse));
     // Initialize the UART helper.
@@ -350,8 +377,7 @@ static UartDemoApp *uart_demo_app_alloc()
 #ifdef DEMO_PROCESS_LINE
     uart_helper_set_delimiter(app->uart_helper, LINE_DELIMITER,
                               INCLUDE_LINE_DELIMITER);
-    uart_helper_set_callback(app->uart_helper, handle_default_response,
-                             app);
+    uart_helper_set_callback(app->uart_helper, app);
 #else
     app->timer =
         furi_timer_alloc(uart_demo_timer_callback, FuriTimerTypePeriodic,

--- a/applications_user/uart_demo/uart_demo.c
+++ b/applications_user/uart_demo/uart_demo.c
@@ -104,12 +104,19 @@ static void setup_lora_connexion(void *context)
     app->lora_bitmask |= CONFIG;
 
 }
+static void decode_data(char *data)
+{
+    // Decode the data received from the server
+    // This function is a placeholder and should be implemented according to the specific requirements
+    FURI_LOG_I("DECODE_DATA", "Data: %s", data);
+}
 static void send_cmsg(UartDemoApp *app, const char *msg)
 {   
     furi_string_printf(app->send_cmd, "AT+CMSG=%s\n", msg);
     uart_helper_send_string(app->uart_helper, app->send_cmd,
                             CMSG);
     furi_delay_ms(1000);
+    DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
 }
 static void uart_demo_submenu_item_callback(void *context, uint32_t index)
 {
@@ -217,10 +224,7 @@ int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response) {
 void handle_msg_response(FuriString *line, void *context)
 {
     UartDemoApp *app = context;
-    FURI_LOG_I("handle_cmsg_response", "%s",
-               furi_string_get_cstr(line));
     parse_msg_response(line, app->msg_response);
-    DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
 }
 void handle_join_response(FuriString *line, void *context)
 {

--- a/applications_user/uart_demo/uart_demo.c
+++ b/applications_user/uart_demo/uart_demo.c
@@ -168,6 +168,26 @@ static int trim_until_delimiter(FuriString *line, char delimiter)
     return 0;
 }
 
+// -- UTILITY FUNCTIONS ---------------------------------------------
+
+// Function to convert hex string to ASCII string
+static void hex_to_string(char *hex_str, char *output_str)
+{
+    size_t len = strlen(hex_str);
+
+    if (len % 2 != 0) {
+        printf("Error: Hex string length must be even.\n");
+        return;
+    }
+
+    for (size_t i = 0; i < len; i += 2) {
+        char hex_pair[3] = { hex_str[i], hex_str[i + 1], '\0' };
+        output_str[i / 2] = (char) strtol(hex_pair, NULL, 16);
+    }
+
+    output_str[len / 2] = '\0'; // Null-terminate the string
+}
+
 // -- INDIVIDUAL PARSERS -----------------------------------------------
 
 static int parse_pending(FuriString *line, LoRaMsgResponse *msg_response)
@@ -316,7 +336,10 @@ void handle_rx_response(FuriString *line, void *context)
 {
     UartDemoApp *app = (UartDemoApp *) context;
     parse_msg_response(line, app->msg_response);
-    DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
+    hex_to_string(app->msg_response->data,
+                  app->msg_response->decoded_data);
+    FURI_LOG_I("handle_rx_response", "Decoded data: %s",
+               app->msg_response->decoded_data);
 }
 
 void handle_join_response(FuriString *line, void *context)
@@ -329,6 +352,8 @@ void handle_join_response(FuriString *line, void *context)
         return;
     }
 }
+
+
 
 #ifdef DEMO_PROCESS_LINE
 void handle_default_response(FuriString *line, void *context)

--- a/applications_user/uart_demo/uart_demo.c
+++ b/applications_user/uart_demo/uart_demo.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include "uart_demo.h"
 
-
 // Global variables
 int dr = DEFAULT_DR;            // Data rate
 int tx_power = DEFAULT_TX_POWER; // Transmit power
@@ -63,7 +62,6 @@ static void otaa_join_procedure(void *context)
         }
 
         FURI_LOG_I("OTAA_JOIN", "Join attempt %d", join_attempts);
-
     }
 }
 
@@ -96,7 +94,6 @@ static void setup_lora_connexion(void *context)
     furi_delay_ms(1000);
 
     app->current_state = CONFIG;
-
 }
 
 // static void decode_data(char *data)
@@ -157,114 +154,113 @@ static void uart_demo_submenu_item_callback(void *context, uint32_t index)
     }
 }
 
-int parse_msg_response(FuriString *line, LoRaMsgResponse *msg_response)
+/**
+ * Trim everything before and including the given delimiter.
+ * Returns -1 if delimiter not found.
+ */
+static int trim_until_delimiter(FuriString *line, char delimiter)
 {
-    if (!line || !msg_response)
-        return -1;
-
-    // Parse the line to extract the fields
-    size_t index;
-    FURI_LOG_D("parse_msg_response", "%s", furi_string_get_cstr(line));
-
-    // Get delimiter `:` index
-    index = furi_string_search_char(line, ':', 0);
+    size_t index = furi_string_search_char(line, delimiter, 0);
     if (index == FURI_STRING_FAILURE) {
-        return -1;              // No delimiter found
+        return -1;
     }
-    // Extract the right part of the line
-    furi_string_right(line, index + 1); // Trim
+    furi_string_right(line, index + 1);
+    return 0;
+}
 
-    index = furi_string_search_str(line, "FPENDING", 0);
-    if (index != FURI_STRING_FAILURE) {
+// -- INDIVIDUAL PARSERS -----------------------------------------------
+
+static int parse_pending(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    if (furi_string_search_str(line, "FPENDING", 0) != FURI_STRING_FAILURE) {
         msg_response->is_pending = true;
         return 0;
     }
+    return 1;
+}
 
-    index = furi_string_search_str(line, "Link ", 0);
-    if (index != FURI_STRING_FAILURE) {
-        char *endptr;
-        const char *str_start = furi_string_get_cstr(line) + index + 5;
 
-        // Extract margin
-        msg_response->margin = (uint8_t) strtol(str_start, &endptr, 10);
+static int parse_link_info(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    size_t index = furi_string_search_str(line, "Link ", 0);
+    if (index == FURI_STRING_FAILURE)
+        return 1;
 
-        // Extract gateway_count if there's a comma
-        if (*endptr == ',') {
-            msg_response->gateway_count =
-                (uint8_t) strtol(endptr + 1, NULL, 10);
-        }
-        return 0;
+    const char *str_start = furi_string_get_cstr(line) + index + 5;
+    char *endptr = NULL;
+    msg_response->margin = (uint8_t) strtol(str_start, &endptr, 10);
+
+    if (*endptr == ',') {
+        msg_response->gateway_count =
+            (uint8_t) strtol(endptr + 1, NULL, 10);
     }
+    return 0;
+}
 
-    index = furi_string_search_str(line, "RXWIN", 0);
-    if (index != FURI_STRING_FAILURE) {
-        msg_response->rx_window =
-            (uint8_t) (furi_string_get_char(line, index + 5) - '0');
 
-        char *endptr;
-        const char *str_start = furi_string_get_cstr(line) + index + 14;
+static int parse_rxwin_info(FuriString *line,
+                            LoRaMsgResponse *msg_response)
+{
+    size_t index = furi_string_search_str(line, "RXWIN", 0);
+    if (index == FURI_STRING_FAILURE)
+        return 1;
 
-        // Extract RSSI value
-        msg_response->rssi = -(int8_t) strtol(str_start, &endptr, 10);
+    msg_response->rx_window =
+        (uint8_t) (furi_string_get_char(line, index + 5) - '0');
 
-        // Extract SNR value
-        msg_response->snr = (int8_t) strtol(endptr + 6, NULL, 10);
-        return 0;
-    }
+    const char *str_start = furi_string_get_cstr(line) + index + 14;
+    char *endptr = NULL;
 
-    index = furi_string_search_str(line, "ACK Received", 0);
-    if (index != FURI_STRING_FAILURE) {
+    msg_response->rssi = -(int8_t) strtol(str_start, &endptr, 10);
+    msg_response->snr = (int8_t) strtol(endptr + 6, NULL, 10);
+    return 0;
+}
+
+static int parse_ack(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    if (furi_string_search_str(line, "ACK Received", 0) !=
+        FURI_STRING_FAILURE) {
         msg_response->is_ack = true;
         return 0;
     }
+    return 1;
+}
 
-    index = furi_string_search_str(line, "MULTICAST", 0);
-    if (index != FURI_STRING_FAILURE) {
+static int parse_multicast(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    if (furi_string_search_str(line, "MULTICAST", 0) !=
+        FURI_STRING_FAILURE) {
         msg_response->is_multicast = true;
         return 0;
     }
+    return 1;
+}
 
-    index = furi_string_search_str(line, "PORT: ", 0);
+static int parse_port(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    size_t index = furi_string_search_str(line, "PORT: ", 0);
     if (index != FURI_STRING_FAILURE) {
         const char *str_start = furi_string_get_cstr(line) + index + 6;
         msg_response->port = (uint8_t) strtol(str_start, NULL, 10);
     }
-
-    index = furi_string_search_str(line, "RX: ", 0);
-    if (index != FURI_STRING_FAILURE) {
-        const char *data_start = furi_string_get_cstr(line) + index + 5; // Skip RX: "
-        strcpy(msg_response->data, data_start);
-
-        size_t length = strlen(msg_response->data);
-        if (length > 0 && msg_response->data[length - 2] == '"') {
-            msg_response->data[length - 2] = '\0'; // Remove the trailing quote
-        }
-        return 0;
-    }
-
     return 0;
 }
 
-static int parse_rx_response(FuriString *line,
-                             LoRaMsgResponse *rx_response)
+// Function to parse the RX packet without trimming the input string
+int parse_rx_packet(FuriString *line, LoRaMsgResponse *rx_response)
 {
     if (!line || !rx_response)
         return -1;
-    // Parse the line to extract the fields
-    size_t index;
-    FURI_LOG_D("parse_rx_response", "%s", furi_string_get_cstr(line));
 
-    // Get delimiter `:` index
-    index = furi_string_search_char(line, ':', 0);
-    if (index == FURI_STRING_FAILURE) {
-        return -1;              // No delimiter found
+    // Check if the line contains "RX"
+    if (furi_string_search_str(line, "RX", 0) == FURI_STRING_FAILURE) {
+        return 1;
     }
-    // Extract the right part of the line
-    furi_string_right(line, index + 1); // Trim
 
-    index = furi_string_search_str(line, "RX", 0);
+    size_t index = furi_string_search_char(line, '"', 0) + 1; // Skip the first quote
+
     if (index != FURI_STRING_FAILURE) {
-        const char *data_start = furi_string_get_cstr(line) + index + 4; // Skip RX "
+        const char *data_start = furi_string_get_cstr(line) + index;
         strcpy(rx_response->data, data_start);
 
         size_t length = strlen(rx_response->data);
@@ -277,17 +273,49 @@ static int parse_rx_response(FuriString *line,
     return 0;
 }
 
+int parse_msg_response(FuriString *line, LoRaMsgResponse *msg_response)
+{
+    if (!line || !msg_response)
+        return -1;
+
+    FURI_LOG_D("parse_msg_response", "%s", furi_string_get_cstr(line));
+
+    if (trim_until_delimiter(line, ':') < 0) {
+        return -1;              // Delimiter not found
+    }
+    // Try each parser until one succeeds
+    if (parse_pending(line, msg_response) == 0)
+        return 0;
+    if (parse_link_info(line, msg_response) == 0)
+        return 0;
+    if (parse_rxwin_info(line, msg_response) == 0)
+        return 0;
+    if (parse_ack(line, msg_response) == 0)
+        return 0;
+    if (parse_multicast(line, msg_response) == 0)
+        return 0;
+    if (parse_rx_packet(line, msg_response) == 0) {
+        if (parse_port(line, msg_response) == 0) { // Port and Data are in the same line in MSG
+            return 0;
+        }
+    }
+    // If none matched, fallback to RX packet
+    return 1;
+}
+
+
+// -- HANDLERS ---------------------------------------------------------
 
 void handle_msg_response(FuriString *line, void *context)
 {
-    UartDemoApp *app = context;
+    UartDemoApp *app = (UartDemoApp *) context;
     parse_msg_response(line, app->msg_response);
 }
 
 void handle_rx_response(FuriString *line, void *context)
 {
-    UartDemoApp *app = context;
-    parse_rx_response(line, app->msg_response);
+    UartDemoApp *app = (UartDemoApp *) context;
+    parse_msg_response(line, app->msg_response);
     DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
 }
 
@@ -306,12 +334,6 @@ void handle_join_response(FuriString *line, void *context)
 void handle_default_response(FuriString *line, void *context)
 {
     (void) context;
-    // submenu_add_item(
-    //     app->submenu,
-    //     furi_string_get_cstr(line),
-    //     app->index++,
-    //     uart_demo_submenu_item_callback,
-    //     app);
     FURI_LOG_I("UART_DEMO", "%s", furi_string_get_cstr(line));
 }
 #else
@@ -342,7 +364,6 @@ static uint32_t uart_demo_exit(void *context)
     // Exit the app.
     return VIEW_NONE;
 }
-
 
 static UartDemoApp *uart_demo_app_alloc()
 {

--- a/applications_user/uart_demo/uart_demo.c
+++ b/applications_user/uart_demo/uart_demo.c
@@ -27,9 +27,11 @@ static void uart_demo_submenu_add_default_entries(Submenu *submenu,
     submenu_reset(submenu);
     submenu_add_item(submenu, "Clear", 0, uart_demo_submenu_item_callback,
                      context);
-    submenu_add_item(submenu, "OTAA JOIN", 1,
+    submenu_add_item(submenu, "OTAA join", 1,
                      uart_demo_submenu_item_callback, context);
-    submenu_add_item(submenu, "Send Msg 2", 2,
+    submenu_add_item(submenu, "Reiceive Mode", 2,
+                     uart_demo_submenu_item_callback, context);
+    submenu_add_item(submenu, "Send Msg 2", 3,
                      uart_demo_submenu_item_callback, context);
 
     app->index = 3;
@@ -44,7 +46,7 @@ static void otaa_join_procedure(void *context)
     while (!(app->lora_bitmask & JOINED)) {
         FURI_LOG_I("OTAA_JOIN", "Attempting to join the network...");
         // Send the join command
-        uart_helper_send(app->uart_helper, "AT+JOIN\n", 9, JOIN);
+        uart_helper_send(app->uart_helper, "AT+JOIN_CMD\n", 9, JOIN_CMD);
         furi_delay_ms(10000);
         
         if(app->lora_bitmask & JOINED) {
@@ -70,58 +72,91 @@ static void setup_lora_connexion(void *context)
 {
     UartDemoApp *app = context;
 
-    uart_helper_send(app->uart_helper, "AT+ID\n", 7, DEFAULT_MSG_TYPE);
+    uart_helper_send(app->uart_helper, "AT+ID\n", 7, CONFIG_CMD);
     furi_delay_ms(1000);
 
     uart_helper_send(app->uart_helper, "AT+MODE=LWOTAA\n", 16,
-                     DEFAULT_MSG_TYPE);
+                     CONFIG_CMD);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+DR=%d\n", dr);
     uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            DEFAULT_MSG_TYPE);
+                            CONFIG_CMD);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+POWER=%d\n", tx_power);
     uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            DEFAULT_MSG_TYPE);
+                            CONFIG_CMD);
     furi_delay_ms(1000);
 
     uart_helper_send(app->uart_helper, "AT+ADR=ON\n", 11,
-                     DEFAULT_MSG_TYPE);
+                     CONFIG_CMD);
     furi_delay_ms(1000);
 
     uart_helper_send(app->uart_helper, "AT+CLASS=A\n", 12,
-                     DEFAULT_MSG_TYPE);
+                     CONFIG_CMD);
     furi_delay_ms(1000);
 
     furi_string_printf(app->send_cmd, "AT+KEY=APPKEY,%s\n", APPKEY);
     uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            DEFAULT_MSG_TYPE);
+                            CONFIG_CMD);
     furi_delay_ms(1000);
 
     // TODO : change because we need to pass to a specific callback
     app->lora_bitmask |= CONFIG;
 
 }
-static void decode_data(char *data)
-{
-    // Decode the data received from the server
-    // This function is a placeholder and should be implemented according to the specific requirements
-    FURI_LOG_I("DECODE_DATA", "Data: %s", data);
-}
+// static void decode_data(char *data)
+// {
+//     // Decode the data received from the server
+//     // This function is a placeholder and should be implemented according to the specific requirements
+//     FURI_LOG_I("DECODE_DATA", "Data: %s", data);
+// }
 static void send_cmsg(UartDemoApp *app, const char *msg)
 {   
     furi_string_printf(app->send_cmd, "AT+CMSG=%s\n", msg);
     uart_helper_send_string(app->uart_helper, app->send_cmd,
-                            CMSG);
+                            CMSG_CMD);
     furi_delay_ms(1000);
     DEBUG_LORA_MSG_RESPONSE(*app->msg_response);
 }
+
+static void enter_test_mode(UartDemoApp *app)
+{
+    uart_helper_send(app->uart_helper, "AT+MODE=TEST\n", 10, CONFIG_CMD);
+    furi_delay_ms(1000);
+}
+static void enter_rx_mode(UartDemoApp *app)
+{   
+    enter_test_mode(app);
+    furi_delay_ms(1000);
+}
+
 static void uart_demo_submenu_item_callback(void *context, uint32_t index)
 {
     UartDemoApp *app = context;
 
+    switch (index)
+    {
+    case 0:
+        // Clear the submenu and add the default entries.
+        uart_demo_submenu_add_default_entries(app->submenu, app);
+        break;
+    case 1: 
+        setup_lora_connexion(app);
+        otaa_join_procedure(app);
+        break;
+    case 2:
+        // Enter RX mode.
+        enter_rx_mode(app);
+        break;
+    case 3:
+        // Send a confirmed message to the server.
+        send_cmsg(app, "Hello World");
+        break;
+    default:
+        break;
+    }
     if (index == 0) {
         // Clear the submenu and add the default entries.
         uart_demo_submenu_add_default_entries(app->submenu, app);
@@ -130,8 +165,11 @@ static void uart_demo_submenu_item_callback(void *context, uint32_t index)
         otaa_join_procedure(app);
     } else if (index == 2) {
         // Send a confirmed message to the server.
+    
+    } else if (index == 3){
         send_cmsg(app, "Hello World");
-    } else {
+    }
+    else {
         // The item was received data.
     }
 }
@@ -231,7 +269,7 @@ void handle_join_response(FuriString *line, void *context)
     FURI_LOG_I("handle_join_response", "%s",
                furi_string_get_cstr(line));
     UartDemoApp *app = context;
-    if (furi_string_start_with(line, "+JOIN: Network joined")) {
+    if (furi_string_start_with(line, "+JOIN_CMD: Network joined")) {
         app->lora_bitmask |= JOINED;
         FURI_LOG_I("handle_join_response", "Network joined");
         return;

--- a/applications_user/uart_demo/uart_demo.h
+++ b/applications_user/uart_demo/uart_demo.h
@@ -31,6 +31,7 @@ typedef struct {
     int8_t snr;                 // SNR (Signal-to-Noise Ratio) of the last frame.
     uint8_t port;               // Port number used in the last transmission.
     char data[MAX_DATA_SIZE];   // Payload data of the last transmitted frame.
+    char decoded_data[MAX_DATA_SIZE]; // Decoded data of the last transmitted frame.
     bool is_multicast;          // True if the frame was received in a multicast group.
     bool is_pending;            // True if the server has pending data for the device.
     bool is_ack;                // True if the last frame was acknowledged by the server.

--- a/applications_user/uart_demo/uart_demo.h
+++ b/applications_user/uart_demo/uart_demo.h
@@ -26,17 +26,25 @@
 #define MAX_DATA_SIZE        (1<<8) // 256 bytes
 
 typedef struct {
-    uint8_t  margin;          // Link margin in dB (0-254) from the last LinkCheckReq.
-    uint16_t gateway_count;   // Number of gateways that received the last transmitted frame.
-    uint8_t  rx_window;       // RX window number where the last frame was received.
-    int8_t   rssi;            // RSSI (Received Signal Strength Indicator) of the last frame.
-    int8_t   snr;             // SNR (Signal-to-Noise Ratio) of the last frame.
-    uint8_t  port;            // Port number used in the last transmission.
-    char     data[MAX_DATA_SIZE];            // Payload data of the last transmitted frame.
-    bool     is_multicast;    // True if the frame was received in a multicast group.
-    bool     is_pending;      // True if the server has pending data for the device.
-    bool     is_ack;         // True if the last frame was acknowledged by the server.
+    uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.
+    uint16_t gateway_count;     // Number of gateways that received the last transmitted frame.
+    uint8_t rx_window;          // RX window number where the last frame was received.
+    int8_t rssi;                // RSSI (Received Signal Strength Indicator) of the last frame.
+    int8_t snr;                 // SNR (Signal-to-Noise Ratio) of the last frame.
+    uint8_t port;               // Port number used in the last transmission.
+    char data[MAX_DATA_SIZE];   // Payload data of the last transmitted frame.
+    bool is_multicast;          // True if the frame was received in a multicast group.
+    bool is_pending;            // True if the server has pending data for the device.
+    bool is_ack;                // True if the last frame was acknowledged by the server.
 } LoRaMsgResponse;
+
+typedef enum {
+    INIT,                       // Being on this state means the device is not configured yet
+    CONFIG,                     // Being on this state means the device has been configured (e.g. AppKey, DR, TxPower)
+    JOINED,                     // Being on this state means the device has joined the network
+    SENDING,                    // Being on this state means the device is sending data
+    RX,                         // Being on this state means the device is receiving data
+} LoraStateFlag;
 
 typedef struct {
     Gui *gui;
@@ -47,42 +55,44 @@ typedef struct {
     UartHelper *uart_helper;
     FuriString *send_cmd;
     LoRaMsgResponse *msg_response;
-    uint32_t lora_bitmask; // Bitmask to store the state of the LoRa device
+    LoraStateFlag current_state;
 } UartDemoApp;
-
-typedef enum{
-    CONFIG = 1, // Being on this state means the device has been configured (e.g. AppKey, DR, TxPower)
-    JOINED = 2, // Being on this state means the device has joined the network
-    SENDING = 4, // Being on this state means the device is sending data
-} LoraStateFlags;
 
 typedef enum {
     UartDemoSubMenuViewId = 1,
 } UartDemoViewIds;
 
 
-
 #define DEBUG_LORA_MSG_RESPONSE(msg_response) \
-    FURI_LOG_I("DebugMsgResponse", "LoRaMsgResponse Debug:"); \
-    FURI_LOG_I("DebugMsgResponse", "  Port: %hhu", (msg_response).port); \
-    FURI_LOG_I("DebugMsgResponse", "  Data: %s", (msg_response).data); \
-    FURI_LOG_I("DebugMsgResponse", "  Margin: %hhu", (msg_response).margin); \
-    FURI_LOG_I("DebugMsgResponse", "  Gateway Count: %u", (msg_response).gateway_count); \
-    FURI_LOG_I("DebugMsgResponse", "  RX Window: %d", (msg_response).rx_window); \
-    FURI_LOG_I("DebugMsgResponse", "  RSSI: %d dBm", (msg_response).rssi); \
-    FURI_LOG_I("DebugMsgResponse", "  SNR: %d dB", (msg_response).snr); \
-    FURI_LOG_I("DebugMsgResponse", "  Multicast: %s", (msg_response).is_multicast ? "Yes" : "No"); \
-    FURI_LOG_I("DebugMsgResponse", "  Pending: %s", (msg_response).is_pending ? "Yes" : "No"); \
-    FURI_LOG_I("DebugMsgResponse", "  ACK Received: %s", (msg_response).is_ack ? "Yes" : "No");
+    FURI_LOG_D("DebugMsgResponse", "LoRaMsgResponse Debug:"); \
+    FURI_LOG_D("DebugMsgResponse", "  Port: %hhu", (msg_response).port); \
+    FURI_LOG_D("DebugMsgResponse", "  Data: %s", (msg_response).data); \
+    FURI_LOG_D("DebugMsgResponse", "  Margin: %hhu", (msg_response).margin); \
+    FURI_LOG_D("DebugMsgResponse", "  Gateway Count: %u", (msg_response).gateway_count); \
+    FURI_LOG_D("DebugMsgResponse", "  RX Window: %d", (msg_response).rx_window); \
+    FURI_LOG_D("DebugMsgResponse", "  RSSI: %d dBm", (msg_response).rssi); \
+    FURI_LOG_D("DebugMsgResponse", "  SNR: %d dB", (msg_response).snr); \
+    FURI_LOG_D("DebugMsgResponse", "  Multicast: %s", (msg_response).is_multicast ? "Yes" : "No"); \
+    FURI_LOG_D("DebugMsgResponse", "  Pending: %s", (msg_response).is_pending ? "Yes" : "No"); \
+    FURI_LOG_D("DebugMsgResponse", "  ACK Received: %s", (msg_response).is_ack ? "Yes" : "No");
 
 // Callback to handle UART responses
 void handle_default_response(FuriString * line, void *context);
 void handle_msg_response(FuriString * line, void *context);
 void handle_join_response(FuriString * line, void *context);
 
+/**
+ * @brief Handles the reception of a LoRa packet in TEST mode (P2P LoRa).
+ *
+ * This function is triggered on the receiver side when a LoRa packet is 
+ * received from the transmitter during TEST mode operation. It decodes the
+ * data and updates the LoRaMsgResponse structure with the received data.
+ */
+void handle_rx_response(FuriString * line, void *context);
+
 
 // Parse the response from the server
-int parse_msg_response(FuriString* line, LoRaMsgResponse* msg_response);
+int parse_msg_response(FuriString * line, LoRaMsgResponse * msg_response);
 
 
 

--- a/applications_user/uart_demo/uart_demo.h
+++ b/applications_user/uart_demo/uart_demo.h
@@ -11,19 +11,17 @@
 
 #include "uart_helper.h"
 
-
-#define DEVICE_BAUDRATE 9600
-#define DEFAULT_DR 5
+#define DEVICE_BAUDRATE  9600
+#define DEFAULT_DR       5
 #define DEFAULT_TX_POWER 14
-#define APPKEY "2FFA5393E446D6CEC8EB9D9AFA5521F3"
-#define PORT 10
-
+#define APPKEY           "2FFA5393E446D6CEC8EB9D9AFA5521F3"
+#define PORT             10
 
 // Comment out the following line to process data as it is received.
 #define DEMO_PROCESS_LINE
 #define LINE_DELIMITER         '\n'
 #define INCLUDE_LINE_DELIMITER false
-#define MAX_DATA_SIZE        (1<<8) // 256 bytes
+#define MAX_DATA_SIZE          (1 << 8) // 256 bytes
 
 typedef struct {
     uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.
@@ -62,17 +60,17 @@ typedef enum {
     UartDemoSubMenuViewId = 1,
 } UartDemoViewIds;
 
-
-#define DEBUG_LORA_MSG_RESPONSE(msg_response) \
-    FURI_LOG_D("DebugMsgResponse", "LoRaMsgResponse Debug:"); \
-    FURI_LOG_D("DebugMsgResponse", "  Port: %hhu", (msg_response).port); \
-    FURI_LOG_D("DebugMsgResponse", "  Data: %s", (msg_response).data); \
-    FURI_LOG_D("DebugMsgResponse", "  Margin: %hhu", (msg_response).margin); \
-    FURI_LOG_D("DebugMsgResponse", "  Gateway Count: %u", (msg_response).gateway_count); \
-    FURI_LOG_D("DebugMsgResponse", "  RX Window: %d", (msg_response).rx_window); \
-    FURI_LOG_D("DebugMsgResponse", "  RSSI: %d dBm", (msg_response).rssi); \
-    FURI_LOG_D("DebugMsgResponse", "  SNR: %d dB", (msg_response).snr); \
-    FURI_LOG_D("DebugMsgResponse", "  Multicast: %s", (msg_response).is_multicast ? "Yes" : "No"); \
+#define DEBUG_LORA_MSG_RESPONSE(msg_response)                                                  \
+    FURI_LOG_D("DebugMsgResponse", "LoRaMsgResponse Debug:");                                  \
+    FURI_LOG_D("DebugMsgResponse", "  Port: %hhu", (msg_response).port);                       \
+    FURI_LOG_D("DebugMsgResponse", "  Data: %s", (msg_response).data);                         \
+    FURI_LOG_D("DebugMsgResponse", "  Margin: %hhu", (msg_response).margin);                   \
+    FURI_LOG_D("DebugMsgResponse", "  Gateway Count: %u", (msg_response).gateway_count);       \
+    FURI_LOG_D("DebugMsgResponse", "  RX Window: %d", (msg_response).rx_window);               \
+    FURI_LOG_D("DebugMsgResponse", "  RSSI: %d dBm", (msg_response).rssi);                     \
+    FURI_LOG_D("DebugMsgResponse", "  SNR: %d dB", (msg_response).snr);                        \
+    FURI_LOG_D(                                                                                \
+        "DebugMsgResponse", "  Multicast: %s", (msg_response).is_multicast ? "Yes" : "No");    \
     FURI_LOG_D("DebugMsgResponse", "  Pending: %s", (msg_response).is_pending ? "Yes" : "No"); \
     FURI_LOG_D("DebugMsgResponse", "  ACK Received: %s", (msg_response).is_ack ? "Yes" : "No");
 
@@ -90,11 +88,8 @@ void handle_join_response(FuriString * line, void *context);
  */
 void handle_rx_response(FuriString * line, void *context);
 
-
-// Parse the response from the server
+// Parse a LoRa packet
 int parse_msg_response(FuriString * line, LoRaMsgResponse * msg_response);
-
-
 
 
 #endif

--- a/applications_user/uart_demo/uart_helper.c
+++ b/applications_user/uart_demo/uart_helper.c
@@ -13,14 +13,6 @@
 #include "uart_demo.h"
 #include "uart_helper.h"
 
-static ProcessLine callbacks[CMD_TYPE_COUNT] = {
-    handle_default_response,    // DEFAULT
-    handle_msg_response,        // MSG
-    handle_msg_response,        // CMSG (same as MSG because we process response the same way)
-    handle_join_response        // JOIN
-};
-
-
 /** 
  * Invoked when a byte of data is received on the UART bus.  This function
  * adds the byte to the stream buffer and sets the WorkerEventDataWaiting flag.
@@ -62,6 +54,9 @@ static int32_t uart_helper_worker(void *context)
             furi_thread_flags_wait(WorkerEventDataWaiting |
                                    WorkerEventExiting, FuriFlagWaitAny,
                                    FuriWaitForever);
+
+        // Update callback depending on the current state
+        uart_helper_set_callback(helper, helper->context);
 
         if (events & WorkerEventDataWaiting) {
             size_t length_read = 0;
@@ -115,16 +110,15 @@ static int32_t uart_helper_worker(void *context)
                         do {
                             // Find the next delimiter in the ring buffer.
                             index =
-                                ring_buffer_find_delim(helper->
-                                                       ring_buffer);
+                                ring_buffer_find_delim
+                                (helper->ring_buffer);
 
                             // If a delimiter was found, extract the line and process it.
                             if (index != FURI_STRING_FAILURE) {
                                 // Extract the line from the ring buffer, advancing the read
                                 // pointer to the next byte after the delimiter.
-                                ring_buffer_extract_line(helper->
-                                                         ring_buffer,
-                                                         index, line);
+                                ring_buffer_extract_line
+                                    (helper->ring_buffer, index, line);
 
                                 // Invoke the callback to process the line.
                                 if (helper->process_line) {
@@ -208,12 +202,30 @@ void uart_helper_set_delimiter(UartHelper *helper, char delimiter,
                               include_delimiter);
 }
 
-void uart_helper_set_callback(UartHelper *helper, ProcessLine process_line,
-                              void *context)
+void uart_helper_set_callback(UartHelper *helper, void *context)
 {
     // Set the process_line callback and context.
-    helper->process_line = process_line;
     helper->context = context;
+    UartDemoApp *app = context;
+    FURI_LOG_D("uart_helper_set_callback", "current_state: %d",
+               app->current_state);
+    switch (app->current_state) {
+    case CONFIG:
+        helper->process_line = handle_default_response;
+        break;
+    case JOINED:
+        helper->process_line = handle_join_response;
+        break;
+    case SENDING:
+        helper->process_line = handle_msg_response;
+        break;
+    case RX:
+        helper->process_line = handle_rx_response;
+        break;
+    default:
+        helper->process_line = handle_default_response;
+        break;
+    }
 }
 
 void uart_helper_set_baud_rate(UartHelper *helper, uint32_t baud_rate)
@@ -228,10 +240,8 @@ bool uart_helper_read(UartHelper *helper, FuriString *text)
     return ring_buffer_read(helper->ring_buffer, text);
 }
 
-void uart_helper_send(UartHelper *helper, const char *data, size_t length,
-                      CmdType cmd_type)
+void uart_helper_send(UartHelper *helper, const char *data, size_t length)
 {
-    uart_helper_set_callback(helper, callbacks[cmd_type], helper->context);
     if (length == 0) {
         length = strlen(data);  // Exclude the null character.
         char *buf = malloc(length + 2); // Null and delimiter.
@@ -243,14 +253,14 @@ void uart_helper_send(UartHelper *helper, const char *data, size_t length,
                            length);
         free(buf);
     } else {
+        FURI_LOG_D("uart_helper_send", data);
         // Transmit data via UART TX.
         furi_hal_serial_tx(helper->serial_handle, (uint8_t *) data,
                            length);
     }
 }
 
-void uart_helper_send_string(UartHelper *helper, FuriString *string,
-                             CmdType cmd_type)
+void uart_helper_send_string(UartHelper *helper, FuriString *string)
 {
     const char *str = furi_string_get_cstr(string);
 
@@ -262,7 +272,7 @@ void uart_helper_send_string(UartHelper *helper, FuriString *string,
     }
 
     // Transmit data
-    uart_helper_send(helper, str, length, cmd_type);
+    uart_helper_send(helper, str, length);
 }
 
 void uart_helper_free(UartHelper *helper)

--- a/applications_user/uart_demo/uart_helper.c
+++ b/applications_user/uart_demo/uart_helper.c
@@ -13,7 +13,7 @@
 #include "uart_demo.h"
 #include "uart_helper.h"
 
-static ProcessLine callbacks[MESSAGE_TYPE_COUNT] = {
+static ProcessLine callbacks[CMD_TYPE_COUNT] = {
     handle_default_response,    // DEFAULT
     handle_msg_response,        // MSG
     handle_msg_response,        // CMSG (same as MSG because we process response the same way)
@@ -229,9 +229,9 @@ bool uart_helper_read(UartHelper *helper, FuriString *text)
 }
 
 void uart_helper_send(UartHelper *helper, const char *data, size_t length,
-                      MessageType msg_type)
+                      CmdType cmd_type)
 {
-    uart_helper_set_callback(helper, callbacks[msg_type], helper->context);
+    uart_helper_set_callback(helper, callbacks[cmd_type], helper->context);
     if (length == 0) {
         length = strlen(data);  // Exclude the null character.
         char *buf = malloc(length + 2); // Null and delimiter.
@@ -250,7 +250,7 @@ void uart_helper_send(UartHelper *helper, const char *data, size_t length,
 }
 
 void uart_helper_send_string(UartHelper *helper, FuriString *string,
-                             MessageType msg_type)
+                             CmdType cmd_type)
 {
     const char *str = furi_string_get_cstr(string);
 
@@ -262,7 +262,7 @@ void uart_helper_send_string(UartHelper *helper, FuriString *string,
     }
 
     // Transmit data
-    uart_helper_send(helper, str, length, msg_type);
+    uart_helper_send(helper, str, length, cmd_type);
 }
 
 void uart_helper_free(UartHelper *helper)

--- a/applications_user/uart_demo/uart_helper.h
+++ b/applications_user/uart_demo/uart_helper.h
@@ -59,15 +59,16 @@ typedef struct {
 } UartHelper;
 
 typedef enum {
-    DEFAULT_MSG_TYPE = 0,
-    MSG = 1,
-    CMSG = 2,
-    JOIN = 3,
-    MESSAGE_TYPE_COUNT,
-} MessageType;
+    DEFAULT_CMD = 0,
+    MSG_CMD = 1,
+    CMSG_CMD = 2,
+    JOIN_CMD = 3,
+    CONFIG_CMD = 4,
+    CMD_TYPE_COUNT,
+} CmdType;
 
 typedef struct {
-    MessageType msg_type;
+    CmdType msg_type;
     ProcessLine process_line;
 } UpLinkHandler;
 /**
@@ -118,13 +119,13 @@ bool uart_helper_read(UartHelper * helper, FuriString * text);
  * Sends data over the UART TX pin.
 */
 void uart_helper_send(UartHelper * helper, const char *data, size_t length,
-                      MessageType msg_type);
+                      CmdType msg_type);
 
 /**
  * Sends a string over the UART TX pin.
 */
 void uart_helper_send_string(UartHelper * helper, FuriString * string,
-                             MessageType msg_type);
+                             CmdType msg_type);
 
 /**
  * Frees the UartHelper & enables log messages.

--- a/applications_user/uart_demo/uart_helper.h
+++ b/applications_user/uart_demo/uart_helper.h
@@ -99,8 +99,7 @@ void uart_helper_set_delimiter(UartHelper * helper, char delimiter,
  * @param process_line  The callback function.
  * @param context       The context to pass to the callback function.
 */
-void uart_helper_set_callback(UartHelper * helper,
-                              ProcessLine process_line, void *context);
+void uart_helper_set_callback(UartHelper * helper, void *context);
 
 /**
  * Sets the baud rate for the UART.  The default is 115200.
@@ -118,14 +117,13 @@ bool uart_helper_read(UartHelper * helper, FuriString * text);
 /**
  * Sends data over the UART TX pin.
 */
-void uart_helper_send(UartHelper * helper, const char *data, size_t length,
-                      CmdType msg_type);
+void uart_helper_send(UartHelper * helper, const char *data,
+                      size_t length);
 
 /**
  * Sends a string over the UART TX pin.
 */
-void uart_helper_send_string(UartHelper * helper, FuriString * string,
-                             CmdType msg_type);
+void uart_helper_send_string(UartHelper * helper, FuriString * string);
 
 /**
  * Frees the UartHelper & enables log messages.


### PR DESCRIPTION
# What's new

- Added the ability to enter test mode by clicking on "Receive Mode". This test mode is a LoRa P2P mode that enables end-node devices to communicate directly with each other.

- Implemented message parsing for TX (transmit) messages in receive mode. For example, when an end node sends a "hello world" message, the flipper, when in receive mode, can receive, parse, and decode it. The decoded result will be saved in the app->decoded_data field.

- Refactored all parser functions for improved maintainability

# Verification 

- I create a Unit Test to test that the TX message the flipper received (in test mode) is correctly parsed and decoded.