### PR TITLE
11 add a config scene

### DIFF
--- a/applications_user/lora/lora_app.c
+++ b/applications_user/lora/lora_app.c
@@ -44,6 +44,11 @@ static LoraApp *lora_app_alloc()
     view_dispatcher_add_view(app->view_dispatcher, LoraAppSubMenuView,
                              submenu_get_view(app->submenu));
 
+    app->var_item_list = variable_item_list_alloc();
+    view_dispatcher_add_view(app->view_dispatcher, LoraAppReceiverCfgView,
+                             variable_item_list_get_view(app->
+                                                         var_item_list));
+
 
     // Allocate a transmitter object
     UartHelper *uart_helper = uart_helper_alloc(DEVICE_BAUDRATE, app);
@@ -93,7 +98,10 @@ static void lora_app_free(LoraApp *app)
 
     view_dispatcher_remove_view(app->view_dispatcher, LoraAppSubMenuView);
     view_dispatcher_remove_view(app->view_dispatcher, LoraAppReceiverView);
+    view_dispatcher_remove_view(app->view_dispatcher,
+                                LoraAppReceiverCfgView);
     view_dispatcher_free(app->view_dispatcher);
+    scene_manager_free(app->scene_manager);
     submenu_free(app->submenu);
     lora_receiver_free(app->receiver);
     lora_transmitter_free(app->transmitter);

--- a/applications_user/lora/lora_app.h
+++ b/applications_user/lora/lora_app.h
@@ -5,8 +5,9 @@
 #include <furi_hal.h>
 #include <gui/gui.h>
 #include <gui/modules/submenu.h>
-#include <gui/modules/text_box.h>
 #include <gui/view_dispatcher.h>
+#include <gui/modules/variable_item_list.h>
+
 #include <gui/canvas.h>
 #include <input/input.h>
 
@@ -39,6 +40,7 @@ typedef struct {
     SceneManager *scene_manager;
     LoraStateManager *state_manager;
     Submenu *submenu;
+    VariableItemList *var_item_list;
     uint32_t index;
     LoraReceiver *receiver;
     LoraTransmitter *transmitter;
@@ -48,6 +50,7 @@ typedef struct {
 typedef enum {
     LoraAppSubMenuView,
     LoraAppReceiverView,
+    LoraAppReceiverCfgView,
 } LoraAppView;
 
 // Callback to handle UART responses

--- a/applications_user/lora/lora_config.h
+++ b/applications_user/lora/lora_config.h
@@ -3,13 +3,13 @@
 #include <furi.h>
 
 extern const uint32_t bandwidth_list[];
-
+extern const uint8_t canal_list[];
 /**
  * @brief LoRa configuration Object
  */
 typedef struct {
     uint32_t freq;              // Frequency in MHz
-    uint8_t canal;              // Canal number (1-8)
+    uint8_t canal_idx;          // Canal index (see canal_list)
     uint8_t sf;                 // Spreading factor
     uint8_t bw_idx;             // Bandwidth index (see bandwidth_list)
     uint8_t tx_preamble;        // TX preamble length

--- a/applications_user/lora/lora_config.h
+++ b/applications_user/lora/lora_config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <furi.h>
+
+extern const uint32_t bandwidth_list[];
+
+/**
+ * @brief LoRa configuration Object
+ */
+typedef struct {
+    uint32_t freq;              // Frequency in MHz
+    uint8_t canal;              // Canal number (1-8)
+    uint8_t sf;                 // Spreading factor
+    uint8_t bw_idx;             // Bandwidth index (see bandwidth_list)
+    uint8_t tx_preamble;        // TX preamble length
+    uint8_t rx_preamble;        // RX preamble length
+    uint8_t power;              // Power level (dbm)
+    bool with_crc;              // CRC enabled/disabled
+    bool is_iq_inverted;        // IQ inversion enabled/disabled
+    bool with_public_lorawan;   // Public LoRaWAN enabled/disabled
+} LoraConfigModel;

--- a/applications_user/lora/lora_custom_event.h
+++ b/applications_user/lora/lora_custom_event.h
@@ -5,4 +5,5 @@ typedef enum {
     LoraReceiverEventUpCanal,
     LoraReceiverEventDownCanal,
     LoraReceiverEventConfig,
+    LoraReceiverEventCfgSet,
 } LoraCustomEvent;

--- a/applications_user/lora/lora_custom_event.h
+++ b/applications_user/lora/lora_custom_event.h
@@ -4,4 +4,5 @@ typedef enum {
     LoraCustomEventRxResponse,
     LoraReceiverEventUpCanal,
     LoraReceiverEventDownCanal,
+    LoraReceiverEventConfig,
 } LoraCustomEvent;

--- a/applications_user/lora/lora_transmitter.c
+++ b/applications_user/lora/lora_transmitter.c
@@ -151,11 +151,13 @@ void lora_transmitter_set_rf_test_config(LoraTransmitter *transmitter,
     furi_assert(transmitter);
     furi_assert(config);
     char temp[256];
+    lora_state_manager_set_state(transmitter->state_manager, CONFIG);
 
     snprintf(temp,
              sizeof(temp),
-             "AT+TEST=RFCFG,%ld,SF%d,%ld,%d,%d,%d,%s,%s,%s\n",
+             "AT+TEST=RFCFG,%ld.%d,SF%d,%ld,%d,%d,%d,%s,%s,%s\n",
              config->freq,
+             canal_list[config->canal_idx],
              config->sf,
              bandwidth_list[config->bw_idx],
              config->tx_preamble,
@@ -166,4 +168,6 @@ void lora_transmitter_set_rf_test_config(LoraTransmitter *transmitter,
              config->with_public_lorawan ? "ON" : "OFF");
 
     transmitter->send_method(transmitter->context, temp, strlen(temp) + 1);
+    furi_delay_ms(1000);        // TODO remove this delay by adjusting the state machine
+
 }

--- a/applications_user/lora/lora_transmitter.c
+++ b/applications_user/lora/lora_transmitter.c
@@ -1,7 +1,6 @@
 #include "lora_transmitter_i.h"
 #include "lora_app.h"
 
-
 static void lora_transmitter_init_cfg_model(void *context)
 {
     furi_assert(context);
@@ -28,8 +27,6 @@ LoraTransmitter *lora_transmitter_alloc(void *context,
     furi_assert(context);
     LoraTransmitter *transmitter = malloc(sizeof(LoraTransmitter));
     transmitter->model = malloc(sizeof(LoraTransmitterModel));
-    // Allocate a string to store sendings commands
-    transmitter->send_cmd = furi_string_alloc();
     transmitter->context = context;
     transmitter->send_method = send_method;
     transmitter->context_destructor = context_destructor;
@@ -43,7 +40,6 @@ void lora_transmitter_free(LoraTransmitter *transmitter)
 {
     transmitter->context_destructor(transmitter->context);
     free(transmitter->model);
-    furi_string_free(transmitter->send_cmd);
     free(transmitter);
 }
 
@@ -74,7 +70,6 @@ void lora_transmitter_set_state_manager(LoraTransmitter *transmitter,
 
 void lora_transmitter_otaa_join_procedure(LoraTransmitter *transmitter)
 {
-
     int join_attempts = 1;
 
     // Loop until the device is joined to the network
@@ -109,33 +104,33 @@ void lora_transmitter_otaa_join_procedure(LoraTransmitter *transmitter)
 
 void lora_transmitter_setup_lorawan(LoraTransmitter *transmitter)
 {
-    UartHelper *uart_helper = transmitter->context;
-
+    char temp[64] = { 0 };
     transmitter->send_method(transmitter->context, "AT+ID\n", 7);
     furi_delay_ms(1000);
 
     transmitter->send_method(transmitter->context, "AT+MODE=LWOTAA\n", 16);
     furi_delay_ms(1000);
 
-    furi_string_printf(transmitter->send_cmd, "AT+DR=%d\n",
-                       transmitter->model->cfg.dr);
-    uart_helper_send_string(uart_helper, transmitter->send_cmd);
+    snprintf(temp, sizeof(temp), "AT+DR=%d\n", transmitter->model->cfg.dr);
+    transmitter->send_method(transmitter->context, temp, strlen(temp) + 1); // +1 for \0
     furi_delay_ms(1000);
 
-    furi_string_printf(transmitter->send_cmd, "AT+POWER=%d\n",
-                       transmitter->model->cfg.tx_power);
-    uart_helper_send_string(uart_helper, transmitter->send_cmd);
+    snprintf(temp, sizeof(temp), "AT+POWER=%d\n",
+             transmitter->model->cfg.tx_power);
+    transmitter->send_method(transmitter->context, temp, strlen(temp) + 1);
     furi_delay_ms(1000);
 
-    transmitter->send_method(transmitter->context, "AT+ADR=ON\n", 11);
+    transmitter->send_method(transmitter->context, "AT+ADR=ON\n",
+                             strlen(temp) + 1);
     furi_delay_ms(1000);
 
-    transmitter->send_method(transmitter->context, "AT+CLASS=A\n", 12);
+    transmitter->send_method(transmitter->context, "AT+CLASS=A\n",
+                             strlen(temp) + 1);
     furi_delay_ms(1000);
 
-    furi_string_printf(transmitter->send_cmd, "AT+KEY=APPKEY,%s\n",
-                       transmitter->model->cfg.appkey);
-    uart_helper_send_string(uart_helper, transmitter->send_cmd);
+    snprintf(temp, sizeof(temp), "AT+KEY=APPKEY,%s\n",
+             transmitter->model->cfg.appkey);
+    transmitter->send_method(transmitter->context, temp, strlen(temp) + 1);
     furi_delay_ms(1000);
 
     lora_state_manager_set_state(transmitter->state_manager, CONFIG);
@@ -144,8 +139,31 @@ void lora_transmitter_setup_lorawan(LoraTransmitter *transmitter)
 void lora_transmitter_send_cmsg(LoraTransmitter *transmitter,
                                 const char *msg)
 {
-    UartHelper *uart_helper = transmitter->context;
-    furi_string_printf(transmitter->send_cmd, "AT+CMSG=%s\n", msg);
-    uart_helper_send_string(uart_helper, transmitter->send_cmd);
+    char temp[64] = { 0 };
+    snprintf(temp, sizeof(temp), "AT+CMSG=%s\n", msg);
+    transmitter->send_method(transmitter->context, temp, strlen(temp) + 1);
     furi_delay_ms(1000);
+}
+
+void lora_transmitter_set_rf_test_config(LoraTransmitter *transmitter,
+                                         LoraConfigModel *config)
+{
+    furi_assert(transmitter);
+    furi_assert(config);
+    char temp[256];
+
+    snprintf(temp,
+             sizeof(temp),
+             "AT+TEST=RFCFG,%ld,SF%d,%ld,%d,%d,%d,%s,%s,%s\n",
+             config->freq,
+             config->sf,
+             bandwidth_list[config->bw_idx],
+             config->tx_preamble,
+             config->rx_preamble,
+             config->power,
+             config->with_crc ? "ON" : "OFF",
+             config->is_iq_inverted ? "ON" : "OFF",
+             config->with_public_lorawan ? "ON" : "OFF");
+
+    transmitter->send_method(transmitter->context, temp, strlen(temp) + 1);
 }

--- a/applications_user/lora/lora_transmitter.h
+++ b/applications_user/lora/lora_transmitter.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "lora_state_manager.h"
+#include "lora_config.h"
 #include <furi.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
     typedef struct LoraTransmitter LoraTransmitter;
 
@@ -59,7 +59,6 @@ extern "C" {
     void lora_transmitter_otaa_join_procedure(LoraTransmitter *
                                               transmitter);
 
-
 /**
  * @brief Setup configuration for LoRaWAN
  * @param transmitter Pointer to the LoraTransmitter object.
@@ -74,8 +73,6 @@ extern "C" {
     void lora_transmitter_send_cmsg(LoraTransmitter * transmitter,
                                     const char *msg);
 
-
-
 /**
  * @brief Set the state manager for the LoRa Transmitter
  * @param transmitter Pointer to the LoraTransmitter object.
@@ -84,6 +81,14 @@ extern "C" {
     void lora_transmitter_set_state_manager(LoraTransmitter * transmitter,
                                             LoraStateManager *
                                             state_manager);
+
+/**
+ * @brief Set RF configuration in test mode by sending AT command (eg: AT+TEST=RFCFG,866,SF12,125,12,15,14,ON,OFF, OFF)
+ * @param transmitter Pointer to the LoraTransmitter object.
+ * @param config Pointer to the configuration object.
+ */
+    void lora_transmitter_set_rf_test_config(LoraTransmitter * transmitter,
+                                             LoraConfigModel * config);
 
 #ifdef __cplusplus
 }

--- a/applications_user/lora/lora_transmitter_i.h
+++ b/applications_user/lora/lora_transmitter_i.h
@@ -34,7 +34,6 @@ typedef struct {
 struct LoraTransmitter {
     void *context;
     LoraStateManager *state_manager;
-    FuriString *send_cmd;
     LoraTransmitterMethod send_method;
     LoraTransmitterModel *model;
     LoraTransmitterContextDestructor context_destructor;

--- a/applications_user/lora/scenes/lora_scene_config.h
+++ b/applications_user/lora/scenes/lora_scene_config.h
@@ -1,5 +1,5 @@
 ADD_SCENE(lora, start, Start)
     ADD_SCENE(lora, receive_mode, ReceiveMode)
-// ADD_SCENE(lora, receiv_mode_cfg, ReceiveModeCfg)
+    ADD_SCENE(lora, receive_mode_cfg, ReceiveModeCfg)
 // ADD_SCENE(lora, lorawan, Lorawan)
 // ADD_SCENE(lora, lorawan_cfg, LorawanCfg)

--- a/applications_user/lora/scenes/lora_scene_receive_mode.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode.c
@@ -1,10 +1,21 @@
 #include "lora_scene.h"
 #include "lora_app.h"
 
+
+void lora_scene_receive_mode_callback(LoraCustomEvent event, void *context)
+{
+    furi_assert(context);
+    LoraApp *app = context;
+    FURI_LOG_D("LoraSceneReceiveMode", "Received event: %d", event);
+    view_dispatcher_send_custom_event(app->view_dispatcher, event);
+}
+
 void lora_scene_receive_mode_on_enter(void *context)
 {
     FURI_LOG_D("LoraSceneReceiveMode", "Entering Lora Scene Receive Mode");
     LoraApp *app = context;
+    lora_receiver_set_view_callback(app->receiver,
+                                    lora_scene_receive_mode_callback, app);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverView);
 }
@@ -20,9 +31,10 @@ bool lora_scene_receive_mode_on_event(void *context,
     FURI_LOG_D("lora_scene_receive_mode_on_event", "Event: %ld",
                event.event);
     if (event.type == SceneManagerEventTypeCustom) {
-        if (event.event == LoraCustomEventRxResponse) {
-            // Display the received message
-            // text_box_set_text(app->text_box, app->receiver->msg_response->decoded_data);
+        if (event.event == LoraReceiverEventConfig) {
+            scene_manager_next_scene(app->scene_manager,
+                                     LoraSceneReceiveModeCfg);
+            consumed = true;
         }
     }
 

--- a/applications_user/lora/scenes/lora_scene_receive_mode.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode.c
@@ -1,5 +1,7 @@
 #include "lora_scene.h"
 #include "lora_app.h"
+#include "lora_config.h"
+#include "views/lora_receiver_i.h"
 
 
 void lora_scene_receive_mode_callback(LoraCustomEvent event, void *context)
@@ -35,6 +37,16 @@ bool lora_scene_receive_mode_on_event(void *context,
             scene_manager_next_scene(app->scene_manager,
                                      LoraSceneReceiveModeCfg);
             consumed = true;
+        } else if (event.event == LoraReceiverEventCfgSet) {
+            consumed = true;
+            with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                            // Send the new configuration to the receiver
+                            LoraConfigModel config_copy;
+                            config_copy = model->config;
+                            lora_transmitter_set_rf_test_config
+                            (app->transmitter, &config_copy);}
+                            , false);
+            lora_state_manager_set_state(app->state_manager, RX);
         }
     }
 

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,7 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;}
+                    model->config.sf = new_sf;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -29,7 +30,8 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;}
+                    model->config.bw_idx = new_bw;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -45,7 +47,8 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;}
+                    model->config.tx_preamble = new_preamble;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -61,7 +64,8 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;}
+                    model->config.rx_preamble = new_preamble;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -78,7 +82,8 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;}
+                    model->config.power = new_power;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -94,7 +99,8 @@ static void line_crc_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.with_crc = new_crc;}
+                    model->config.with_crc = new_crc;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -110,7 +116,8 @@ static void line_iq_inverted_cb(VariableItem *item)
              new_iq_inverted ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.is_iq_inverted = new_iq_inverted;}
+                    model->config.is_iq_inverted = new_iq_inverted;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -130,7 +137,8 @@ static void line_public_lorawan_cb(VariableItem *item)
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     model->config.with_public_lorawan =
-                    new_with_public_lorawan;}
+                    new_with_public_lorawan;
+                    }
                     , false);
     view_dispatcher_send_custom_event(app->view_dispatcher,
                                       LoraReceiverEventCfgSet);
@@ -214,7 +222,8 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     add_boolean_line(app,
                                      model->config.with_public_lorawan,
                                      "Public LoraWan",
-                                     line_public_lorawan_cb);}, false);
+                                     line_public_lorawan_cb);
+                    }, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }
@@ -237,11 +246,10 @@ bool lora_scene_receive_mode_cfg_on_event(void *context,
                             // Send the new configuration to the receiver
                             LoraConfigModel config_copy;
                             config_copy = model->config;
-                            lora_transmitter_set_rf_test_config(app->
-                                                                transmitter,
-                                                                &config_copy);}
+                            lora_transmitter_set_rf_test_config
+                            (app->transmitter, &config_copy);}
                             , false);
-
+            lora_state_manager_set_state(app->state_manager, RX);
 
         }
     }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,7 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;}
+                    model->config.sf = new_sf;
+                    }
                     , false);
 }
 
@@ -39,7 +40,8 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;}
+                    model->config.bw_idx = new_bw;
+                    }
                     , false);
 }
 
@@ -66,7 +68,8 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;}
+                    model->config.tx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -94,7 +97,8 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;}
+                    model->config.rx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -112,6 +116,33 @@ static void line_rx_preamble(LoraApp *app, LoraReceiverModel *model)
     variable_item_set_current_value_text(item, temp);
 }
 
+static void line_power_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[4];
+    uint8_t new_power =
+        variable_item_get_current_value_index(item) + MIN_POWER;
+    snprintf(temp, sizeof(temp), "%u", new_power);
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.power = new_power;
+                    }
+                    , false);
+}
+
+static void line_power(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "Power",
+                                  MAX_POWER - MIN_POWER + 1,
+                                  line_power_cb, app);
+    variable_item_set_current_value_index(item,
+                                          model->config.power - MIN_POWER);
+    char temp[4];
+    snprintf(temp, sizeof(temp), "%u", model->config.power);
+    variable_item_set_current_value_text(item, temp);
+}
 
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
@@ -123,7 +154,7 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     line_bw(app, model);
                     line_tx_preamble(app, model);
                     line_rx_preamble(app, model);
-                    }, false);
+                    line_power(app, model);}, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }
@@ -131,7 +162,7 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
 void lora_scene_receive_mode_cfg_on_exit(void *context)
 {
     LoraApp *app = context;
-    UNUSED(app);
+    variable_item_list_reset(app->var_item_list);
 }
 
 bool lora_scene_receive_mode_cfg_on_event(void *context,

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,8 +13,7 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;
-                    }
+                    model->config.sf = new_sf;}
                     , false);
 }
 
@@ -40,8 +39,7 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;
-                    }
+                    model->config.bw_idx = new_bw;}
                     , false);
 }
 
@@ -49,7 +47,7 @@ static void line_bw(LoraApp *app, LoraReceiverModel *model)
 {
     VariableItem *item;
     item = variable_item_list_add(app->var_item_list,
-                                  "BW",
+                                  "Band width",
                                   BANDWIDTH_LIST_SIZE, line_bw_cb, app);
     variable_item_set_current_value_index(item, model->config.bw_idx);
     char temp[4];
@@ -58,13 +56,74 @@ static void line_bw(LoraApp *app, LoraReceiverModel *model)
     variable_item_set_current_value_text(item, temp);
 }
 
+static void line_tx_preamble_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[4];
+    uint8_t new_preamble =
+        variable_item_get_current_value_index(item) + MIN_PREAMBLE;
+    snprintf(temp, sizeof(temp), "%u", new_preamble);
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.tx_preamble = new_preamble;}
+                    , false);
+}
+
+static void line_tx_preamble(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "TX Preamble",
+                                  MAX_PREAMBLE - MIN_PREAMBLE + 1,
+                                  line_tx_preamble_cb, app);
+    variable_item_set_current_value_index(item,
+                                          model->config.tx_preamble -
+                                          MIN_PREAMBLE);
+    char temp[4];
+    snprintf(temp, sizeof(temp), "%u", model->config.tx_preamble);
+    variable_item_set_current_value_text(item, temp);
+}
+
+static void line_rx_preamble_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[4];
+    uint8_t new_preamble =
+        variable_item_get_current_value_index(item) + MIN_PREAMBLE;
+    snprintf(temp, sizeof(temp), "%u", new_preamble);
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.rx_preamble = new_preamble;}
+                    , false);
+}
+
+static void line_rx_preamble(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "RX Preamble",
+                                  MAX_PREAMBLE - MIN_PREAMBLE + 1,
+                                  line_rx_preamble_cb, app);
+    variable_item_set_current_value_index(item,
+                                          model->config.rx_preamble -
+                                          MIN_PREAMBLE);
+    char temp[4];
+    snprintf(temp, sizeof(temp), "%u", model->config.rx_preamble);
+    variable_item_set_current_value_text(item, temp);
+}
+
+
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
     FURI_LOG_D("LoraSceneReceiveModeCfg",
                "Entering Lora Scene Receive Mode");
     LoraApp *app = context;
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    line_sf(app, model); line_bw(app, model);}, false);
+                    line_sf(app, model);
+                    line_bw(app, model);
+                    line_tx_preamble(app, model);
+                    line_rx_preamble(app, model);
+                    }, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -3,6 +3,7 @@
 #include "../views/lora_receiver_i.h"
 #include <gui/modules/variable_item_list.h>
 
+
 static void line_sf_cb(VariableItem *item)
 {
     LoraApp *app = variable_item_get_context(item);
@@ -12,7 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;}
+                    model->config.sf = new_sf;
+                    }
                     , false);
 }
 
@@ -28,6 +30,33 @@ static void line_sf(LoraApp *app, LoraReceiverModel *model)
     variable_item_set_current_value_text(item, temp);
 }
 
+static void line_bw_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[4];
+    uint32_t new_bw =
+        bandwidth_list[variable_item_get_current_value_index(item)];
+    snprintf(temp, sizeof(temp), "%lu", new_bw);
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.bw_idx = new_bw;
+                    }
+                    , false);
+}
+
+static void line_bw(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list,
+                                  "BW",
+                                  BANDWIDTH_LIST_SIZE, line_bw_cb, app);
+    variable_item_set_current_value_index(item, model->config.bw_idx);
+    char temp[4];
+    snprintf(temp, sizeof(temp), "%lu",
+             bandwidth_list[model->config.bw_idx]);
+    variable_item_set_current_value_text(item, temp);
+}
 
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
@@ -35,9 +64,9 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                "Entering Lora Scene Receive Mode");
     LoraApp *app = context;
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    line_sf(app, model);}, false)
-        view_dispatcher_switch_to_view(app->view_dispatcher,
-                                       LoraAppReceiverCfgView);
+                    line_sf(app, model); line_bw(app, model);}, false);
+    view_dispatcher_switch_to_view(app->view_dispatcher,
+                                   LoraAppReceiverCfgView);
 }
 
 void lora_scene_receive_mode_cfg_on_exit(void *context)

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,21 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;
-                    }
+                    model->config.sf = new_sf;}
                     , false);
-}
-
-static void line_sf(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item =
-        variable_item_list_add(app->var_item_list, "SF",
-                               MAX_SF - MIN_SF + 1, line_sf_cb, app);
-    variable_item_set_current_value_index(item, model->config.sf - MIN_SF); // config.sf - MIN_SF because we map the SF to the index
-    char temp[4];
-    snprintf(temp, sizeof(temp), "%u", model->config.sf);
-    variable_item_set_current_value_text(item, temp);
 }
 
 static void line_bw_cb(VariableItem *item)
@@ -40,8 +27,7 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;
-                    }
+                    model->config.bw_idx = new_bw;}
                     , false);
 }
 
@@ -68,23 +54,8 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;
-                    }
+                    model->config.tx_preamble = new_preamble;}
                     , false);
-}
-
-static void line_tx_preamble(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "TX Preamble",
-                                  MAX_PREAMBLE - MIN_PREAMBLE + 1,
-                                  line_tx_preamble_cb, app);
-    variable_item_set_current_value_index(item,
-                                          model->config.tx_preamble -
-                                          MIN_PREAMBLE);
-    char temp[4];
-    snprintf(temp, sizeof(temp), "%u", model->config.tx_preamble);
-    variable_item_set_current_value_text(item, temp);
 }
 
 static void line_rx_preamble_cb(VariableItem *item)
@@ -97,23 +68,8 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;
-                    }
+                    model->config.rx_preamble = new_preamble;}
                     , false);
-}
-
-static void line_rx_preamble(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "RX Preamble",
-                                  MAX_PREAMBLE - MIN_PREAMBLE + 1,
-                                  line_rx_preamble_cb, app);
-    variable_item_set_current_value_index(item,
-                                          model->config.rx_preamble -
-                                          MIN_PREAMBLE);
-    char temp[4];
-    snprintf(temp, sizeof(temp), "%u", model->config.rx_preamble);
-    variable_item_set_current_value_text(item, temp);
 }
 
 static void line_power_cb(VariableItem *item)
@@ -126,22 +82,8 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;
-                    }
+                    model->config.power = new_power;}
                     , false);
-}
-
-static void line_power(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "Power",
-                                  MAX_POWER - MIN_POWER + 1,
-                                  line_power_cb, app);
-    variable_item_set_current_value_index(item,
-                                          model->config.power - MIN_POWER);
-    char temp[4];
-    snprintf(temp, sizeof(temp), "%u", model->config.power);
-    variable_item_set_current_value_text(item, temp);
 }
 
 static void line_crc_cb(VariableItem *item)
@@ -153,8 +95,7 @@ static void line_crc_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.with_crc = new_crc;
-                    }
+                    model->config.with_crc = new_crc;}
                     , false);
 }
 
@@ -168,8 +109,7 @@ static void line_iq_inverted_cb(VariableItem *item)
              new_iq_inverted ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.is_iq_inverted = new_iq_inverted;
-                    }
+                    model->config.is_iq_inverted = new_iq_inverted;}
                     , false);
 }
 
@@ -186,13 +126,29 @@ static void line_public_lorawan_cb(VariableItem *item)
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     model->config.with_public_lorawan =
-                    new_with_public_lorawan;
-                    }
+                    new_with_public_lorawan;}
                     , false);
 }
 
+static void add_value_line(LoraApp *app, uint8_t value_model_field,
+                           uint8_t min_value, uint8_t max_value,
+                           char *value_label,
+                           VariableItemChangeCallback callback)
+{
+    VariableItem *item;
+    char temp[4];
 
-static void add_boolean_line(LoraApp *app, bool *boolean_field,
+    item = variable_item_list_add(app->var_item_list, value_label,
+                                  max_value - min_value + 1, callback,
+                                  app);
+    variable_item_set_current_value_index(item,
+                                          value_model_field - min_value);
+
+    snprintf(temp, sizeof(temp), "%u", value_model_field);
+    variable_item_set_current_value_text(item, temp);
+}
+
+static void add_boolean_line(LoraApp *app, bool boolean_model_field,
                              char *boolean_label,
                              VariableItemChangeCallback callback)
 {
@@ -201,10 +157,10 @@ static void add_boolean_line(LoraApp *app, bool *boolean_field,
 
     item = variable_item_list_add(app->var_item_list, boolean_label,
                                   2, callback, app);
-    variable_item_set_current_value_index(item, *boolean_field);
+    variable_item_set_current_value_index(item, boolean_model_field);
 
     snprintf(temp, sizeof(temp), "%s",
-             *boolean_field ? "Enabled" : "Disabled");
+             boolean_model_field ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
 }
 
@@ -214,17 +170,24 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                "Entering Lora Scene Receive Mode");
     LoraApp *app = context;
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    line_sf(app, model);
+                    add_value_line(app, model->config.sf, MIN_SF, MAX_SF,
+                                   "SF", line_sf_cb);
                     line_bw(app, model);
-                    line_tx_preamble(app, model);
-                    line_rx_preamble(app, model);
-                    line_power(app, model);
-                    add_boolean_line(app, &model->config.with_crc, "CRC",
+                    add_value_line(app, model->config.tx_preamble,
+                                   MIN_PREAMBLE, MAX_PREAMBLE,
+                                   "TX Preamble", line_tx_preamble_cb);
+                    add_value_line(app, model->config.rx_preamble,
+                                   MIN_PREAMBLE, MAX_PREAMBLE,
+                                   "RX Preamble", line_rx_preamble_cb);
+                    add_value_line(app, model->config.power,
+                                   MIN_POWER, MAX_POWER,
+                                   "Power", line_power_cb);
+                    add_boolean_line(app, model->config.with_crc, "CRC",
                                      line_crc_cb);
-                    add_boolean_line(app, &model->config.is_iq_inverted,
+                    add_boolean_line(app, model->config.is_iq_inverted,
                                      "IQ Inverted", line_iq_inverted_cb);
                     add_boolean_line(app,
-                                     &model->config.with_public_lorawan,
+                                     model->config.with_public_lorawan,
                                      "Public LoraWan",
                                      line_public_lorawan_cb);}, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -1,0 +1,47 @@
+#include "lora_scene.h"
+#include "lora_app.h"
+#include "../views/lora_receiver_i.h"
+#include <gui/modules/variable_item_list.h>
+
+static void line_sf_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    UNUSED(index);
+    UNUSED(app);
+}
+
+void lora_scene_receive_mode_cfg_on_enter(void *context)
+{
+    FURI_LOG_D("LoraSceneReceiveModeCfg",
+               "Entering Lora Scene Receive Mode");
+    LoraApp *app = context;
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    VariableItem * item;
+                    item =
+                    variable_item_list_add(app->var_item_list, "SF", 5,
+                                           line_sf_cb, app);
+                    variable_item_set_current_value_index(item,
+                                                          model->config.
+                                                          sf);
+                    variable_item_set_current_value_text(item, "test");},
+                    false)
+        view_dispatcher_switch_to_view(app->view_dispatcher,
+                                       LoraAppReceiverCfgView);
+}
+
+void lora_scene_receive_mode_cfg_on_exit(void *context)
+{
+    LoraApp *app = context;
+    UNUSED(app);
+}
+
+bool lora_scene_receive_mode_cfg_on_event(void *context,
+                                          SceneManagerEvent event)
+{
+    UNUSED(context);
+    UNUSED(event);
+    return false;
+}

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,9 +13,10 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;
-                    }
+                    model->config.sf = new_sf;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
 }
 
 static void line_bw_cb(VariableItem *item)
@@ -28,9 +29,10 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;
-                    }
+                    model->config.bw_idx = new_bw;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
 }
 
 static void line_tx_preamble_cb(VariableItem *item)
@@ -43,9 +45,10 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;
-                    }
+                    model->config.tx_preamble = new_preamble;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
 }
 
 static void line_rx_preamble_cb(VariableItem *item)
@@ -58,9 +61,11 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;
-                    }
+                    model->config.rx_preamble = new_preamble;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
+
 }
 
 static void line_power_cb(VariableItem *item)
@@ -73,9 +78,11 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;
-                    }
+                    model->config.power = new_power;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
+
 }
 
 static void line_crc_cb(VariableItem *item)
@@ -87,9 +94,10 @@ static void line_crc_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.with_crc = new_crc;
-                    }
+                    model->config.with_crc = new_crc;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
 }
 
 static void line_iq_inverted_cb(VariableItem *item)
@@ -102,9 +110,11 @@ static void line_iq_inverted_cb(VariableItem *item)
              new_iq_inverted ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.is_iq_inverted = new_iq_inverted;
-                    }
+                    model->config.is_iq_inverted = new_iq_inverted;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
+
 }
 
 
@@ -120,9 +130,11 @@ static void line_public_lorawan_cb(VariableItem *item)
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     model->config.with_public_lorawan =
-                    new_with_public_lorawan;
-                    }
+                    new_with_public_lorawan;}
                     , false);
+    view_dispatcher_send_custom_event(app->view_dispatcher,
+                                      LoraReceiverEventCfgSet);
+
 }
 
 static void add_list_value_line(LoraApp *app, uint8_t value_model_idx,
@@ -202,8 +214,7 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     add_boolean_line(app,
                                      model->config.with_public_lorawan,
                                      "Public LoraWan",
-                                     line_public_lorawan_cb);
-                    }, false);
+                                     line_public_lorawan_cb);}, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }
@@ -217,7 +228,22 @@ void lora_scene_receive_mode_cfg_on_exit(void *context)
 bool lora_scene_receive_mode_cfg_on_event(void *context,
                                           SceneManagerEvent event)
 {
-    UNUSED(context);
-    UNUSED(event);
-    return false;
+    LoraApp *app = context;
+    bool consumed = false;
+    if (event.type == SceneManagerEventTypeCustom) {
+        if (event.event == LoraReceiverEventCfgSet) {
+            consumed = true;
+            with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                            // Send the new configuration to the receiver
+                            LoraConfigModel config_copy;
+                            config_copy = model->config;
+                            lora_transmitter_set_rf_test_config(app->
+                                                                transmitter,
+                                                                &config_copy);}
+                            , false);
+
+
+        }
+    }
+    return consumed;
 }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -7,11 +7,27 @@ static void line_sf_cb(VariableItem *item)
 {
     LoraApp *app = variable_item_get_context(item);
     furi_assert(app);
-    uint8_t index = variable_item_get_current_value_index(item);
-
-    UNUSED(index);
-    UNUSED(app);
+    char temp[4];
+    uint8_t new_sf = variable_item_get_current_value_index(item) + MIN_SF;
+    snprintf(temp, sizeof(temp), "%u", new_sf);
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.sf = new_sf;}
+                    , false);
 }
+
+static void line_sf(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item =
+        variable_item_list_add(app->var_item_list, "SF",
+                               MAX_SF - MIN_SF + 1, line_sf_cb, app);
+    variable_item_set_current_value_index(item, model->config.sf - MIN_SF); // config.sf - MIN_SF because we map the SF to the index
+    char temp[4];
+    snprintf(temp, sizeof(temp), "%u", model->config.sf);
+    variable_item_set_current_value_text(item, temp);
+}
+
 
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
@@ -19,15 +35,7 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                "Entering Lora Scene Receive Mode");
     LoraApp *app = context;
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    VariableItem * item;
-                    item =
-                    variable_item_list_add(app->var_item_list, "SF", 5,
-                                           line_sf_cb, app);
-                    variable_item_set_current_value_index(item,
-                                                          model->config.
-                                                          sf);
-                    variable_item_set_current_value_text(item, "test");},
-                    false)
+                    line_sf(app, model);}, false)
         view_dispatcher_switch_to_view(app->view_dispatcher,
                                        LoraAppReceiverCfgView);
 }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,8 +13,7 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;
-                    }
+                    model->config.sf = new_sf;}
                     , false);
 }
 
@@ -40,8 +39,7 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;
-                    }
+                    model->config.bw_idx = new_bw;}
                     , false);
 }
 
@@ -68,8 +66,7 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;
-                    }
+                    model->config.tx_preamble = new_preamble;}
                     , false);
 }
 
@@ -97,8 +94,7 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;
-                    }
+                    model->config.rx_preamble = new_preamble;}
                     , false);
 }
 
@@ -126,8 +122,7 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;
-                    }
+                    model->config.power = new_power;}
                     , false);
 }
 
@@ -144,6 +139,90 @@ static void line_power(LoraApp *app, LoraReceiverModel *model)
     variable_item_set_current_value_text(item, temp);
 }
 
+static void line_crc_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[10];
+    bool new_crc = variable_item_get_current_value_index(item);
+    snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.with_crc = new_crc;}
+                    , false);
+}
+
+static void line_crc(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "CRC",
+                                  2, line_crc_cb, app);
+    variable_item_set_current_value_index(item, model->config.with_crc);
+    char temp[10];
+    snprintf(temp, sizeof(temp), "%s",
+             model->config.with_crc ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+}
+
+
+static void line_iq_inverted_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[10];
+    bool new_iq_inverted = variable_item_get_current_value_index(item);
+    snprintf(temp, sizeof(temp), "%s",
+             new_iq_inverted ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.is_iq_inverted = new_iq_inverted;}
+                    , false);
+}
+
+static void line_iq_inverted(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "IQ Inverted",
+                                  2, line_iq_inverted_cb, app);
+    variable_item_set_current_value_index(item,
+                                          model->config.is_iq_inverted);
+    char temp[10];
+    snprintf(temp, sizeof(temp), "%s",
+             model->config.is_iq_inverted ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+}
+
+static void line_public_lorawan_cb(VariableItem *item)
+{
+    LoraApp *app = variable_item_get_context(item);
+    furi_assert(app);
+    char temp[10];
+    bool new_with_public_lorawan =
+        variable_item_get_current_value_index(item);
+    snprintf(temp, sizeof(temp), "%s",
+             new_with_public_lorawan ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    model->config.with_public_lorawan =
+                    new_with_public_lorawan;}
+                    , false);
+}
+
+static void line_public_lorawan(LoraApp *app, LoraReceiverModel *model)
+{
+    VariableItem *item;
+    item = variable_item_list_add(app->var_item_list, "Public LoRaWan",
+                                  2, line_public_lorawan_cb, app);
+    variable_item_set_current_value_index(item,
+                                          model->config.
+                                          with_public_lorawan);
+    char temp[10];
+    snprintf(temp, sizeof(temp), "%s",
+             model->config.with_public_lorawan ? "Enabled" : "Disabled");
+    variable_item_set_current_value_text(item, temp);
+}
+
+
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
     FURI_LOG_D("LoraSceneReceiveModeCfg",
@@ -154,7 +233,10 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     line_bw(app, model);
                     line_tx_preamble(app, model);
                     line_rx_preamble(app, model);
-                    line_power(app, model);}, false);
+                    line_power(app, model);
+                    line_crc(app, model);
+                    line_iq_inverted(app, model);
+                    line_public_lorawan(app, model);}, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,7 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;}
+                    model->config.sf = new_sf;
+                    }
                     , false);
 }
 
@@ -39,7 +40,8 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;}
+                    model->config.bw_idx = new_bw;
+                    }
                     , false);
 }
 
@@ -66,7 +68,8 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;}
+                    model->config.tx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -94,7 +97,8 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;}
+                    model->config.rx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -122,7 +126,8 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;}
+                    model->config.power = new_power;
+                    }
                     , false);
 }
 
@@ -148,22 +153,10 @@ static void line_crc_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.with_crc = new_crc;}
+                    model->config.with_crc = new_crc;
+                    }
                     , false);
 }
-
-static void line_crc(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "CRC",
-                                  2, line_crc_cb, app);
-    variable_item_set_current_value_index(item, model->config.with_crc);
-    char temp[10];
-    snprintf(temp, sizeof(temp), "%s",
-             model->config.with_crc ? "Enabled" : "Disabled");
-    variable_item_set_current_value_text(item, temp);
-}
-
 
 static void line_iq_inverted_cb(VariableItem *item)
 {
@@ -175,22 +168,11 @@ static void line_iq_inverted_cb(VariableItem *item)
              new_iq_inverted ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.is_iq_inverted = new_iq_inverted;}
+                    model->config.is_iq_inverted = new_iq_inverted;
+                    }
                     , false);
 }
 
-static void line_iq_inverted(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "IQ Inverted",
-                                  2, line_iq_inverted_cb, app);
-    variable_item_set_current_value_index(item,
-                                          model->config.is_iq_inverted);
-    char temp[10];
-    snprintf(temp, sizeof(temp), "%s",
-             model->config.is_iq_inverted ? "Enabled" : "Disabled");
-    variable_item_set_current_value_text(item, temp);
-}
 
 static void line_public_lorawan_cb(VariableItem *item)
 {
@@ -204,24 +186,27 @@ static void line_public_lorawan_cb(VariableItem *item)
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     model->config.with_public_lorawan =
-                    new_with_public_lorawan;}
+                    new_with_public_lorawan;
+                    }
                     , false);
 }
 
-static void line_public_lorawan(LoraApp *app, LoraReceiverModel *model)
+
+static void add_boolean_line(LoraApp *app, bool *boolean_field,
+                             char *boolean_label,
+                             VariableItemChangeCallback callback)
 {
     VariableItem *item;
-    item = variable_item_list_add(app->var_item_list, "Public LoRaWan",
-                                  2, line_public_lorawan_cb, app);
-    variable_item_set_current_value_index(item,
-                                          model->config.
-                                          with_public_lorawan);
     char temp[10];
+
+    item = variable_item_list_add(app->var_item_list, boolean_label,
+                                  2, callback, app);
+    variable_item_set_current_value_index(item, *boolean_field);
+
     snprintf(temp, sizeof(temp), "%s",
-             model->config.with_public_lorawan ? "Enabled" : "Disabled");
+             *boolean_field ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
 }
-
 
 void lora_scene_receive_mode_cfg_on_enter(void *context)
 {
@@ -234,9 +219,14 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     line_tx_preamble(app, model);
                     line_rx_preamble(app, model);
                     line_power(app, model);
-                    line_crc(app, model);
-                    line_iq_inverted(app, model);
-                    line_public_lorawan(app, model);}, false);
+                    add_boolean_line(app, &model->config.with_crc, "CRC",
+                                     line_crc_cb);
+                    add_boolean_line(app, &model->config.is_iq_inverted,
+                                     "IQ Inverted", line_iq_inverted_cb);
+                    add_boolean_line(app,
+                                     &model->config.with_public_lorawan,
+                                     "Public LoraWan",
+                                     line_public_lorawan_cb);}, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }

--- a/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
+++ b/applications_user/lora/scenes/lora_scene_receive_mode_cfg.c
@@ -13,7 +13,8 @@ static void line_sf_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_sf);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.sf = new_sf;}
+                    model->config.sf = new_sf;
+                    }
                     , false);
 }
 
@@ -27,21 +28,9 @@ static void line_bw_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%lu", new_bw);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.bw_idx = new_bw;}
+                    model->config.bw_idx = new_bw;
+                    }
                     , false);
-}
-
-static void line_bw(LoraApp *app, LoraReceiverModel *model)
-{
-    VariableItem *item;
-    item = variable_item_list_add(app->var_item_list,
-                                  "Band width",
-                                  BANDWIDTH_LIST_SIZE, line_bw_cb, app);
-    variable_item_set_current_value_index(item, model->config.bw_idx);
-    char temp[4];
-    snprintf(temp, sizeof(temp), "%lu",
-             bandwidth_list[model->config.bw_idx]);
-    variable_item_set_current_value_text(item, temp);
 }
 
 static void line_tx_preamble_cb(VariableItem *item)
@@ -54,7 +43,8 @@ static void line_tx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.tx_preamble = new_preamble;}
+                    model->config.tx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -68,7 +58,8 @@ static void line_rx_preamble_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_preamble);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.rx_preamble = new_preamble;}
+                    model->config.rx_preamble = new_preamble;
+                    }
                     , false);
 }
 
@@ -82,7 +73,8 @@ static void line_power_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%u", new_power);
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.power = new_power;}
+                    model->config.power = new_power;
+                    }
                     , false);
 }
 
@@ -95,7 +87,8 @@ static void line_crc_cb(VariableItem *item)
     snprintf(temp, sizeof(temp), "%s", new_crc ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.with_crc = new_crc;}
+                    model->config.with_crc = new_crc;
+                    }
                     , false);
 }
 
@@ -109,7 +102,8 @@ static void line_iq_inverted_cb(VariableItem *item)
              new_iq_inverted ? "Enabled" : "Disabled");
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
-                    model->config.is_iq_inverted = new_iq_inverted;}
+                    model->config.is_iq_inverted = new_iq_inverted;
+                    }
                     , false);
 }
 
@@ -126,19 +120,36 @@ static void line_public_lorawan_cb(VariableItem *item)
     variable_item_set_current_value_text(item, temp);
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     model->config.with_public_lorawan =
-                    new_with_public_lorawan;}
+                    new_with_public_lorawan;
+                    }
                     , false);
+}
+
+static void add_list_value_line(LoraApp *app, uint8_t value_model_idx,
+                                const uint32_t list[], uint8_t list_size,
+                                const char *label,
+                                VariableItemChangeCallback callback)
+{
+    VariableItem *item;
+    char temp[4];
+
+    item = variable_item_list_add(app->var_item_list, label,
+                                  list_size, callback, app);
+    variable_item_set_current_value_index(item, value_model_idx);
+
+    snprintf(temp, sizeof(temp), "%lu", list[value_model_idx]);
+    variable_item_set_current_value_text(item, temp);
 }
 
 static void add_value_line(LoraApp *app, uint8_t value_model_field,
                            uint8_t min_value, uint8_t max_value,
-                           char *value_label,
+                           char *label,
                            VariableItemChangeCallback callback)
 {
     VariableItem *item;
     char temp[4];
 
-    item = variable_item_list_add(app->var_item_list, value_label,
+    item = variable_item_list_add(app->var_item_list, label,
                                   max_value - min_value + 1, callback,
                                   app);
     variable_item_set_current_value_index(item,
@@ -172,16 +183,18 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
     with_view_model(app->receiver->view, LoraReceiverModel * model, {
                     add_value_line(app, model->config.sf, MIN_SF, MAX_SF,
                                    "SF", line_sf_cb);
-                    line_bw(app, model);
+                    add_list_value_line(app, model->config.bw_idx,
+                                        bandwidth_list,
+                                        BANDWIDTH_LIST_SIZE, "BW",
+                                        line_bw_cb);
                     add_value_line(app, model->config.tx_preamble,
                                    MIN_PREAMBLE, MAX_PREAMBLE,
                                    "TX Preamble", line_tx_preamble_cb);
                     add_value_line(app, model->config.rx_preamble,
                                    MIN_PREAMBLE, MAX_PREAMBLE,
                                    "RX Preamble", line_rx_preamble_cb);
-                    add_value_line(app, model->config.power,
-                                   MIN_POWER, MAX_POWER,
-                                   "Power", line_power_cb);
+                    add_value_line(app, model->config.power, MIN_POWER,
+                                   MAX_POWER, "Power", line_power_cb);
                     add_boolean_line(app, model->config.with_crc, "CRC",
                                      line_crc_cb);
                     add_boolean_line(app, model->config.is_iq_inverted,
@@ -189,7 +202,8 @@ void lora_scene_receive_mode_cfg_on_enter(void *context)
                     add_boolean_line(app,
                                      model->config.with_public_lorawan,
                                      "Public LoraWan",
-                                     line_public_lorawan_cb);}, false);
+                                     line_public_lorawan_cb);
+                    }, false);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppReceiverCfgView);
 }

--- a/applications_user/lora/views/lora_receiver.c
+++ b/applications_user/lora/views/lora_receiver.c
@@ -193,8 +193,8 @@ void lora_receiver_decode_msg_response(LoraReceiver *receiver,
     with_view_model(receiver->view, LoraReceiverModel * model, {
                     parse_msg_response(line, &model->msg_response);
                     hex_to_string(model->msg_response.data,
-                                  model->msg_response.decoded_data);
-                    }, true);
+                                  model->msg_response.decoded_data);},
+                    true);
 }
 
 static void lora_receiver_draw_callback(Canvas *canvas, void *_model)
@@ -222,6 +222,7 @@ static void lora_receiver_draw_callback(Canvas *canvas, void *_model)
 
     elements_button_up(canvas, "");
     elements_button_down(canvas, "");
+    elements_button_right(canvas, "Config");
 }
 
 static void lora_receiver_next_canal_callback(LoraReceiver *receiver)
@@ -259,6 +260,10 @@ static bool lora_receiver_input_callback(InputEvent *event, void *context)
         } else if (event->key == InputKeyDown) {
             consumed = true;
             lora_receiver_prev_canal_callback(receiver);
+        } else if (event->key == InputKeyRight) {
+            consumed = true;
+            receiver->view_callback(LoraReceiverEventConfig,
+                                    receiver->context);
         }
     }
     return consumed;
@@ -279,8 +284,7 @@ static void lora_receiver_init_cfg_model(void *context)
                     model->config.with_crc = DEFAULT_WITH_CRC;
                     model->config.is_iq_inverted = DEFAULT_IQ_INVERTED;
                     model->config.with_public_lorawan =
-                    DEFAULT_WITH_PUBLIC_LORAWAN;
-                    }, true)
+                    DEFAULT_WITH_PUBLIC_LORAWAN;}, true)
 }
 
 static void lora_receiver_init_msg_model(void *context)
@@ -298,8 +302,7 @@ static void lora_receiver_init_msg_model(void *context)
                     model->msg_response.is_pending = false;
                     model->msg_response.is_ack = false;
                     model->msg_response.data[0] = '\0';
-                    model->msg_response.decoded_data[0] = '\0';
-                    }, true)
+                    model->msg_response.decoded_data[0] = '\0';}, true)
 }
 
 static void lora_receiver_init(void *context)
@@ -314,7 +317,7 @@ LoraReceiver *lora_receiver_alloc(void)
     LoraReceiver *receiver = malloc(sizeof(LoraReceiver));
     furi_assert(receiver);
 
-    receiver->callback = lora_receiver_default_response_callback;
+    receiver->process_callback = lora_receiver_default_response_callback;
     receiver->view = view_alloc();
     view_allocate_model(receiver->view, ViewModelTypeLocking,
                         sizeof(LoraReceiverModel));
@@ -390,14 +393,14 @@ void lora_receiver_update_process_callback(LoraReceiver *receiver,
                                            LoraState state)
 {
     furi_assert(receiver);
-    receiver->callback = lora_receiver_retrieve_callback(state);
+    receiver->process_callback = lora_receiver_retrieve_callback(state);
 }
 
 LoraReceiverProcessCallback lora_receiver_get_callback(LoraReceiver
                                                        *receiver)
 {
     furi_assert(receiver);
-    return receiver->callback;
+    return receiver->process_callback;
 }
 
 void lora_receiver_set_state_manager(LoraReceiver *receiver,
@@ -406,4 +409,16 @@ void lora_receiver_set_state_manager(LoraReceiver *receiver,
     furi_assert(receiver);
     furi_assert(state_manager);
     receiver->state_manager = state_manager;
+}
+
+void lora_receiver_set_view_callback(LoraReceiver *receiver,
+                                     LoraReceiverViewCallbak callback,
+                                     void *context)
+{
+    furi_assert(receiver);
+    furi_assert(callback);
+    with_view_model(receiver->view, LoraReceiverModel * model, {
+                    UNUSED(model);
+                    receiver->view_callback = callback;
+                    receiver->context = context;}, false)
 }

--- a/applications_user/lora/views/lora_receiver.c
+++ b/applications_user/lora/views/lora_receiver.c
@@ -4,6 +4,13 @@
 
 #include <gui/elements.h>
 
+const uint32_t bandwidth_list[] = {
+    125,
+    250,
+    500,
+};
+
+
 /**
  * @brief Convert a hex string to a string.
  * @param hex_str Pointer to the hex string.
@@ -277,148 +284,149 @@ static void lora_receiver_init_cfg_model(void *context)
                     model->config.freq = DEFAULT_FREQ;
                     model->config.canal = DEFAULT_CANAL_NUM;
                     model->config.sf = DEFAULT_SF;
-                    model->config.bw = DEFAULT_BW;
+                    for (size_t i = 0;
+                         i <
+                         sizeof(bandwidth_list) /
+                         sizeof(bandwidth_list[0]); i++) {
+                    if (bandwidth_list[i] == DEFAULT_BW) {
+                    model->config.bw_idx = i; break;}
+                    }
                     model->config.tx_preamble = DEFAULT_TX_PREAMBLE;
                     model->config.rx_preamble = DEFAULT_RX_PREAMBLE;
                     model->config.power = DEFAULT_POWER;
                     model->config.with_crc = DEFAULT_WITH_CRC;
                     model->config.is_iq_inverted = DEFAULT_IQ_INVERTED;
                     model->config.with_public_lorawan =
-                    DEFAULT_WITH_PUBLIC_LORAWAN;}, true)
-}
-
-static void lora_receiver_init_msg_model(void *context)
-{
-    furi_assert(context);
-    LoraReceiver *lora_receiver = context;
-    with_view_model(lora_receiver->view, LoraReceiverModel * model, {
-                    model->msg_response.margin = 0;
-                    model->msg_response.gateway_count = 0;
-                    model->msg_response.rx_window = 0;
-                    model->msg_response.rssi = 0;
-                    model->msg_response.snr = 0;
-                    model->msg_response.port = 0;
-                    model->msg_response.is_multicast = false;
-                    model->msg_response.is_pending = false;
-                    model->msg_response.is_ack = false;
-                    model->msg_response.data[0] = '\0';
-                    model->msg_response.decoded_data[0] = '\0';}, true)
-}
-
-static void lora_receiver_init(void *context)
-{
-    furi_assert(context);
-    lora_receiver_init_cfg_model(context);
-    lora_receiver_init_msg_model(context);
-}
-
-LoraReceiver *lora_receiver_alloc(void)
-{
-    LoraReceiver *receiver = malloc(sizeof(LoraReceiver));
-    furi_assert(receiver);
-
-    receiver->process_callback = lora_receiver_default_response_callback;
-    receiver->view = view_alloc();
-    view_allocate_model(receiver->view, ViewModelTypeLocking,
-                        sizeof(LoraReceiverModel));
-
-    lora_receiver_init(receiver);
-
-    view_set_context(receiver->view, receiver);
-    view_set_draw_callback(receiver->view, lora_receiver_draw_callback);
-    view_set_input_callback(receiver->view, lora_receiver_input_callback);
-    return receiver;
-}
-
-void lora_receiver_free(LoraReceiver *receiver)
-{
-    furi_assert(receiver);
-    view_free_model(receiver->view);
-    view_free(receiver->view);
-    free(receiver);
-}
-
-View *lora_receiver_get_view(LoraReceiver *receiver)
-{
-    furi_assert(receiver);
-    return receiver->view;
-}
-
-void lora_receiver_rx_response_callback(FuriString *line, void *context)
-{
-    furi_assert(context);
-    FURI_LOG_D("lora_receiver_rx_response_callback", "%s",
-               furi_string_get_cstr(line));
-    LoraApp *app = context;
-    lora_receiver_decode_msg_response(app->receiver, line);
-}
-
-void lora_receiver_default_response_callback(FuriString *line,
-                                             void *context)
-{
-    UNUSED(line);
-    UNUSED(context);
-    FURI_LOG_D("lora_receiver_default_response_callback", "received: %s",
-               furi_string_get_cstr(line));
-}
-
-void lora_receiver_join_response_callback(FuriString *line, void *context)
-{
-    FURI_LOG_D("lora_receiver_join_response", "%s",
-               furi_string_get_cstr(line));
-    LoraApp *app = context;
-    if (furi_string_start_with(line, "+JOIN_CMD: Network joined")) {
-        lora_state_manager_set_state(app->state_manager, JOINED);
-        FURI_LOG_D("lora_receiver_join_response", "Network joined");
-        return;
-    }
-}
-
-static LoraReceiverProcessCallback
-lora_receiver_retrieve_callback(LoraState state)
-{
-    switch (state) {
-        {
-    case JOINED:
-            return lora_receiver_join_response_callback;
-    case RX:
-            return lora_receiver_rx_response_callback;
+                    DEFAULT_WITH_PUBLIC_LORAWAN;}
+                    , true)
         }
-    default:
-        return lora_receiver_default_response_callback;
+
+        static void lora_receiver_init_msg_model(void *context) {
+        furi_assert(context);
+        LoraReceiver *lora_receiver = context;
+        with_view_model(lora_receiver->view, LoraReceiverModel * model, {
+                        model->msg_response.margin = 0;
+                        model->msg_response.gateway_count = 0;
+                        model->msg_response.rx_window = 0;
+                        model->msg_response.rssi = 0;
+                        model->msg_response.snr = 0;
+                        model->msg_response.port = 0;
+                        model->msg_response.is_multicast = false;
+                        model->msg_response.is_pending = false;
+                        model->msg_response.is_ack = false;
+                        model->msg_response.data[0] = '\0';
+                        model->msg_response.decoded_data[0] = '\0';}, true)
+        }
+
+    static void lora_receiver_init(void *context) {
+        furi_assert(context);
+        lora_receiver_init_cfg_model(context);
+        lora_receiver_init_msg_model(context);
     }
-}
 
-void lora_receiver_update_process_callback(LoraReceiver *receiver,
-                                           LoraState state)
-{
-    furi_assert(receiver);
-    receiver->process_callback = lora_receiver_retrieve_callback(state);
-}
+    LoraReceiver *lora_receiver_alloc(void) {
+        LoraReceiver *receiver = malloc(sizeof(LoraReceiver));
+        furi_assert(receiver);
 
-LoraReceiverProcessCallback lora_receiver_get_callback(LoraReceiver
-                                                       *receiver)
-{
-    furi_assert(receiver);
-    return receiver->process_callback;
-}
+        receiver->process_callback =
+            lora_receiver_default_response_callback;
+        receiver->view = view_alloc();
+        view_allocate_model(receiver->view, ViewModelTypeLocking,
+                            sizeof(LoraReceiverModel));
 
-void lora_receiver_set_state_manager(LoraReceiver *receiver,
-                                     LoraStateManager *state_manager)
-{
-    furi_assert(receiver);
-    furi_assert(state_manager);
-    receiver->state_manager = state_manager;
-}
+        lora_receiver_init(receiver);
 
-void lora_receiver_set_view_callback(LoraReceiver *receiver,
-                                     LoraReceiverViewCallbak callback,
-                                     void *context)
-{
-    furi_assert(receiver);
-    furi_assert(callback);
-    with_view_model(receiver->view, LoraReceiverModel * model, {
-                    UNUSED(model);
-                    receiver->view_callback = callback;
-                    receiver->context = context;}, false)
-}
+        view_set_context(receiver->view, receiver);
+        view_set_draw_callback(receiver->view,
+                               lora_receiver_draw_callback);
+        view_set_input_callback(receiver->view,
+                                lora_receiver_input_callback);
+        return receiver;
+    }
+
+    void lora_receiver_free(LoraReceiver * receiver) {
+        furi_assert(receiver);
+        view_free_model(receiver->view);
+        view_free(receiver->view);
+        free(receiver);
+    }
+
+    View *lora_receiver_get_view(LoraReceiver * receiver) {
+        furi_assert(receiver);
+        return receiver->view;
+    }
+
+    void lora_receiver_rx_response_callback(FuriString * line,
+                                            void *context) {
+        furi_assert(context);
+        FURI_LOG_D("lora_receiver_rx_response_callback", "%s",
+                   furi_string_get_cstr(line));
+        LoraApp *app = context;
+        lora_receiver_decode_msg_response(app->receiver, line);
+    }
+
+    void lora_receiver_default_response_callback(FuriString * line,
+                                                 void *context) {
+        UNUSED(line);
+        UNUSED(context);
+        FURI_LOG_D("lora_receiver_default_response_callback",
+                   "received: %s", furi_string_get_cstr(line));
+    }
+
+    void lora_receiver_join_response_callback(FuriString * line,
+                                              void *context) {
+        FURI_LOG_D("lora_receiver_join_response", "%s",
+                   furi_string_get_cstr(line));
+        LoraApp *app = context;
+        if (furi_string_start_with(line, "+JOIN_CMD: Network joined")) {
+            lora_state_manager_set_state(app->state_manager, JOINED);
+            FURI_LOG_D("lora_receiver_join_response", "Network joined");
+            return;
+        }
+    }
+
+    static LoraReceiverProcessCallback
+        lora_receiver_retrieve_callback(LoraState state) {
+        switch (state) {
+            {
+        case JOINED:
+                return lora_receiver_join_response_callback;
+        case RX:
+                return lora_receiver_rx_response_callback;
+            }
+        default:
+            return lora_receiver_default_response_callback;
+        }
+    }
+
+    void lora_receiver_update_process_callback(LoraReceiver * receiver,
+                                               LoraState state) {
+        furi_assert(receiver);
+        receiver->process_callback =
+            lora_receiver_retrieve_callback(state);
+    }
+
+    LoraReceiverProcessCallback lora_receiver_get_callback(LoraReceiver *
+                                                           receiver) {
+        furi_assert(receiver);
+        return receiver->process_callback;
+    }
+
+    void lora_receiver_set_state_manager(LoraReceiver * receiver,
+                                         LoraStateManager *
+                                         state_manager) {
+        furi_assert(receiver);
+        furi_assert(state_manager);
+        receiver->state_manager = state_manager;
+    }
+
+    void lora_receiver_set_view_callback(LoraReceiver * receiver,
+                                         LoraReceiverViewCallbak callback,
+                                         void *context) {
+        furi_assert(receiver);
+        furi_assert(callback);
+        with_view_model(receiver->view, LoraReceiverModel * model, {
+                        UNUSED(model);
+                        receiver->view_callback = callback;
+                        receiver->context = context;}, false)
+    }

--- a/applications_user/lora/views/lora_receiver.c
+++ b/applications_user/lora/views/lora_receiver.c
@@ -10,6 +10,11 @@ const uint32_t bandwidth_list[] = {
     500,
 };
 
+const uint8_t canal_list[] = {
+    1,                          // 868.1 is canal 0
+    3,                          // 868.3 is canal 1
+    5,                          // 868.5 is canal 2
+};
 
 /**
  * @brief Convert a hex string to a string.
@@ -212,7 +217,7 @@ static void lora_receiver_draw_callback(Canvas *canvas, void *_model)
     canvas_set_font(canvas, FontPrimary);
 
     snprintf(temp_str, 18, "%ld.%d MHz", model->config.freq,
-             model->config.canal);
+             canal_list[model->config.canal_idx]);
     canvas_draw_str_aligned(canvas, 64, 9, AlignCenter, AlignBottom,
                             temp_str);
 
@@ -236,21 +241,19 @@ static void lora_receiver_next_canal_callback(LoraReceiver *receiver)
 {
     furi_assert(receiver);
     with_view_model(receiver->view, LoraReceiverModel * model, {
-                    model->config.canal++;
-                    if (model->config.canal > MAX_CANAL_NUM) {
-                    model->config.canal = 0;}
-                    }
-                    , true);
+                    model->config.canal_idx =
+                    (model->config.canal_idx + 1) % CANAL_LIST_SIZE;},
+                    true);
 }
 
 static void lora_receiver_prev_canal_callback(LoraReceiver *receiver)
 {
     furi_assert(receiver);
     with_view_model(receiver->view, LoraReceiverModel * model, {
-                    if (model->config.canal > 0) {
-                    model->config.canal--;}
+                    if (model->config.canal_idx > 0) {
+                    model->config.canal_idx--;}
                     else {
-                    model->config.canal = MAX_CANAL_NUM;}
+                    model->config.canal_idx = CANAL_LIST_SIZE - 1;}
                     }
                     , true);
 }
@@ -264,9 +267,13 @@ static bool lora_receiver_input_callback(InputEvent *event, void *context)
         if (event->key == InputKeyUp) {
             consumed = true;
             lora_receiver_next_canal_callback(receiver);
+            receiver->view_callback(LoraReceiverEventCfgSet,
+                                    receiver->context);
         } else if (event->key == InputKeyDown) {
             consumed = true;
             lora_receiver_prev_canal_callback(receiver);
+            receiver->view_callback(LoraReceiverEventCfgSet,
+                                    receiver->context);
         } else if (event->key == InputKeyRight) {
             consumed = true;
             receiver->view_callback(LoraReceiverEventConfig,
@@ -282,7 +289,7 @@ static void lora_receiver_init_cfg_model(void *context)
     LoraReceiver *lora_receiver = context;
     with_view_model(lora_receiver->view, LoraReceiverModel * model, {
                     model->config.freq = DEFAULT_FREQ;
-                    model->config.canal = DEFAULT_CANAL_NUM;
+                    model->config.canal_idx = DEFAULT_CANAL_NUM;
                     model->config.sf = DEFAULT_SF;
                     for (size_t i = 0;
                          i <

--- a/applications_user/lora/views/lora_receiver.h
+++ b/applications_user/lora/views/lora_receiver.h
@@ -3,6 +3,7 @@
 #include <gui/view.h>
 
 #include "../lora_state_manager.h"
+#include "../lora_custom_event.h"
 
 
 #ifdef __cplusplus
@@ -18,6 +19,9 @@ extern "C" {
  */
     typedef void (*LoraReceiverProcessCallback)(FuriString * line,
                                                 void *context);
+
+    typedef void (*LoraReceiverViewCallbak)(LoraCustomEvent event,
+                                            void *context);
 
 
 /**
@@ -68,6 +72,10 @@ extern "C" {
     LoraReceiverProcessCallback lora_receiver_get_callback(LoraReceiver *
                                                            receiver);
 
+
+    void lora_receiver_set_view_callback(LoraReceiver * receiver,
+                                         LoraReceiverViewCallbak callback,
+                                         void *context);
 
     void lora_receiver_set_state_manager(LoraReceiver * receiver,
                                          LoraStateManager * state_manager);

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -22,6 +22,9 @@
 #define MIN_SF (7)              // Minimum Spreading Factor
 #define MAX_SF (12)             // Maximum Spreading Factor
 
+#define MIN_POWER (0)
+#define MAX_POWER (22)          // Power level in dBm
+
 #define MIN_PREAMBLE (6)        // For RX and TX preamble
 #define MAX_PREAMBLE (20)       // For RX and TX preamble
 

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lora_receiver.h"
+#include "../lora_config.h"
 #include "../lora_custom_event.h"
 #include <furi.h>
 
@@ -29,7 +30,6 @@
 #define MAX_PREAMBLE (20)       // For RX and TX preamble
 
 #define BANDWIDTH_LIST_SIZE (3) // Number of bandwidth options (125, 250, 500 kHz)
-extern const uint32_t bandwidth_list[];
 
 typedef struct {
     uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.
@@ -45,21 +45,6 @@ typedef struct {
     bool is_ack;                // True if the last frame was acknowledged by the server.
 } LoraMsgResponseModel;
 
-/**
- * @brief LoRa configuration Object
- */
-typedef struct {
-    uint32_t freq;              // Frequency in MHz
-    uint8_t canal;              // Canal number (1-8)
-    uint8_t sf;                 // Spreading factor
-    uint8_t bw_idx;             // Bandwidth index (see bandwidth_list)
-    uint8_t tx_preamble;        // TX preamble length
-    uint8_t rx_preamble;        // RX preamble length
-    uint8_t power;              // Power level (dbm)
-    bool with_crc;              // CRC enabled/disabled
-    bool is_iq_inverted;        // IQ inversion enabled/disabled
-    bool with_public_lorawan;   // Public LoRaWAN enabled/disabled
-} LoraConfigModel;
 
 /**
  * @brief LoRa Receiver Model

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -22,6 +22,9 @@
 #define MIN_SF (7)              // Minimum Spreading Factor
 #define MAX_SF (12)             // Maximum Spreading Factor
 
+#define MIN_PREAMBLE (6)        // For RX and TX preamble
+#define MAX_PREAMBLE (20)       // For RX and TX preamble
+
 #define BANDWIDTH_LIST_SIZE (3) // Number of bandwidth options (125, 250, 500 kHz)
 extern const uint32_t bandwidth_list[];
 

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -19,11 +19,11 @@
 #define DEFAULT_IQ_INVERTED         (false) // IQ inversion disabled
 #define DEFAULT_WITH_PUBLIC_LORAWAN (false) // Public LoRaWAN enabled
 
-#define MIN_SF (7)              // Minimum Spreading Factor
-#define MAX_SF (12)             // Maximum Spreading Factor
+#define MIN_SF (7)
+#define MAX_SF (12)
 
 #define MIN_POWER (0)
-#define MAX_POWER (22)          // Power level in dBm
+#define MAX_POWER (22)
 
 #define MIN_PREAMBLE (6)        // For RX and TX preamble
 #define MAX_PREAMBLE (20)       // For RX and TX preamble

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -63,7 +63,8 @@ typedef struct {
 struct LoraReceiver {
     View *view;
     void *context;
-    LoraReceiverProcessCallback callback; // Callback function for received messages
+    LoraReceiverViewCallbak view_callback; // Callback function to be called on view events
+    LoraReceiverProcessCallback process_callback; // Callback function for received messages 
     LoraStateManager *state_manager;
 };
 

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -6,7 +6,6 @@
 #include <furi.h>
 
 #define MAX_DATA_SIZE (1 << 8)  // 256 bytes
-#define MAX_CANAL_NUM (8)       // (1-8)
 
 // Default values for LoRa configuration
 #define DEFAULT_FREQ                (868) // Frequency in MHz
@@ -30,6 +29,8 @@
 #define MAX_PREAMBLE (20)       // For RX and TX preamble
 
 #define BANDWIDTH_LIST_SIZE (3) // Number of bandwidth options (125, 250, 500 kHz)
+#define CANAL_LIST_SIZE (3)     // Number of canal options (868.1, 868.3, 868.5 MHz)
+
 
 typedef struct {
     uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -19,6 +19,9 @@
 #define DEFAULT_IQ_INVERTED         (false) // IQ inversion disabled
 #define DEFAULT_WITH_PUBLIC_LORAWAN (false) // Public LoRaWAN enabled
 
+#define MIN_SF (7)              // Minimum Spreading Factor
+#define MAX_SF (12)             // Maximum Spreading Factor
+
 typedef struct {
     uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.
     uint16_t gateway_count;     // Number of gateways that received the last transmitted frame.

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -22,6 +22,9 @@
 #define MIN_SF (7)              // Minimum Spreading Factor
 #define MAX_SF (12)             // Maximum Spreading Factor
 
+#define BANDWIDTH_LIST_SIZE (3) // Number of bandwidth options (125, 250, 500 kHz)
+extern const uint32_t bandwidth_list[];
+
 typedef struct {
     uint8_t margin;             // Link margin in dB (0-254) from the last LinkCheckReq.
     uint16_t gateway_count;     // Number of gateways that received the last transmitted frame.
@@ -43,7 +46,7 @@ typedef struct {
     uint32_t freq;              // Frequency in MHz
     uint8_t canal;              // Canal number (1-8)
     uint8_t sf;                 // Spreading factor
-    uint8_t bw;                 // Bandwidth
+    uint8_t bw_idx;             // Bandwidth index (see bandwidth_list)
     uint8_t tx_preamble;        // TX preamble length
     uint8_t rx_preamble;        // RX preamble length
     uint8_t power;              // Power level (dbm)
@@ -67,7 +70,7 @@ struct LoraReceiver {
     View *view;
     void *context;
     LoraReceiverViewCallbak view_callback; // Callback function to be called on view events
-    LoraReceiverProcessCallback process_callback; // Callback function for received messages 
+    LoraReceiverProcessCallback process_callback; // Callback function for received messages
     LoraStateManager *state_manager;
 };
 

--- a/applications_user/lora/views/lora_receiver_i.h
+++ b/applications_user/lora/views/lora_receiver_i.h
@@ -9,11 +9,11 @@
 
 // Default values for LoRa configuration
 #define DEFAULT_FREQ                (868) // Frequency in MHz
-#define DEFAULT_CANAL_NUM           (1) // Canal 1
-#define DEFAULT_SF                  (12) // Spreading Factor 12
-#define DEFAULT_BW                  (125) // Bandwidth 125 kHz
-#define DEFAULT_TX_PREAMBLE         (12) // TX Preamble length
-#define DEFAULT_RX_PREAMBLE         (15) // RX Preamble length
+#define DEFAULT_CANAL_NUM           (0) // Canal
+#define DEFAULT_SF                  (8) // Spreading Factor
+#define DEFAULT_BW                  (125) // Bandwidth (kHz)
+#define DEFAULT_TX_PREAMBLE         (8) // TX Preamble length
+#define DEFAULT_RX_PREAMBLE         (8) // RX Preamble length
 #define DEFAULT_POWER               (14) // Power level (dBm)
 #define DEFAULT_WITH_CRC            (true) // CRC enabled
 #define DEFAULT_IQ_INVERTED         (false) // IQ inversion disabled


### PR DESCRIPTION
This pull request includes several changes to the LoRa application, focusing on adding the config view, updating the transmitter logic, and introducing a new configuration model. The most important changes are grouped by theme as follows:

### New Config View:

* Added a new view `LoraAppReceiverCfgView` to the view dispatcher and allocated a `VariableItemList` for it in `lora_app_alloc()` (`applications_user/lora/lora_app.c`).
* Removed the new view in `lora_app_free()` and freed the scene manager (`applications_user/lora/lora_app.c`).

### Configuration Model:

* Introduced `LoraConfigModel` struct to manage LoRa configuration settings (`applications_user/lora/lora_config.h`).

### Transmitter Logic Updates:

* Removed the `send_cmd` string allocation and updated logic to use `snprintf` for sending commands (`applications_user/lora/lora_transmitter.c`) [[1]](diffhunk://#diff-04530fa7ad927d26d30ea0846e5ed3887c0a6b670de7a9a03e995e5a4d201e2dL31-L32) [[2]](diffhunk://#diff-04530fa7ad927d26d30ea0846e5ed3887c0a6b670de7a9a03e995e5a4d201e2dL112-R133).
* Added a new function `lora_transmitter_set_rf_test_config` to set RF configuration in test mode (`applications_user/lora/lora_transmitter.c`).

### Scene and Event Handling:

* Added new custom events for receiver configuration (`applications_user/lora/lora_custom_event.h`).
* Updated the receive mode scene to handle new configuration events (`applications_user/lora/scenes/lora_scene_receive_mode.c`).
