### PR TITLE
15 add bluetooth connexion to send string

### DIFF
--- a/applications_user/.gitignore
+++ b/applications_user/.gitignore
@@ -1,1 +1,1 @@
-
+flipper-pc-monitor/

--- a/applications_user/lora/application.fam
+++ b/applications_user/lora/application.fam
@@ -3,7 +3,7 @@ App(
     name="LoRa",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="lora_app_main",
-    requires=["gui"],
+    requires=["bt", "gui"],
     stack_size=1 * 1024,
     fap_icon="lora_10px.png",
     fap_category="GPIO",

--- a/applications_user/lora/bt_transmitter.c
+++ b/applications_user/lora/bt_transmitter.c
@@ -48,11 +48,9 @@ void bt_transmitter_start(BtTransmitter *bt_transmitter)
 
     furi_check(bt_transmitter->ble_serial_profile);
 
-    ble_profile_serial_set_event_callback(bt_transmitter->
-                                          ble_serial_profile,
-                                          BT_SERIAL_BUFFER_SIZE,
-                                          bt_serial_callback,
-                                          bt_transmitter);
+    ble_profile_serial_set_event_callback
+        (bt_transmitter->ble_serial_profile, BT_SERIAL_BUFFER_SIZE,
+         bt_serial_callback, bt_transmitter);
     furi_hal_bt_start_advertising();
 
     bt_transmitter->bt_state = BtStateWaiting;
@@ -85,9 +83,9 @@ void bt_transmitter_start(BtTransmitter *bt_transmitter)
 
 void bt_transmitter_stop(BtTransmitter *bt_transmitter)
 {
-    ble_profile_serial_set_event_callback(bt_transmitter->
-                                          ble_serial_profile, 0, NULL,
-                                          NULL);
+    furi_hal_bt_stop_advertising();
+    ble_profile_serial_set_event_callback
+        (bt_transmitter->ble_serial_profile, 0, NULL, NULL);
 
     bt_disconnect(bt_transmitter->bt);
 
@@ -112,7 +110,11 @@ BtTransmitter *bt_transmitter_alloc(void)
 
 void bt_transmitter_free(BtTransmitter *bt_transmitter)
 {
-    bt_transmitter_stop(bt_transmitter);
+    if (bt_transmitter->bt_state == BtStateWaiting) {
+        FURI_LOG_D("bt_transmitter_free",
+                   "Stopping Bluetooth transmitter");
+        bt_transmitter_stop(bt_transmitter);
+    }
 
     furi_message_queue_free(bt_transmitter->event_queue);
     furi_record_close(RECORD_NOTIFICATION);

--- a/applications_user/lora/bt_transmitter.c
+++ b/applications_user/lora/bt_transmitter.c
@@ -1,7 +1,6 @@
 
 #include "bt_transmitter.h"
 
-
 static uint16_t bt_serial_callback(SerialServiceEvent event, void *context)
 {
     furi_assert(context);
@@ -16,7 +15,7 @@ static uint16_t bt_serial_callback(SerialServiceEvent event, void *context)
         if (event.data.size == sizeof(DataStruct)) {
             memcpy(&bt_transmitter->data, event.data.buffer,
                    sizeof(DataStruct));
-            bt_transmitter->bt_state = BtStateRecieving;
+            bt_transmitter->bt_state = BtStateReceiving;
             bt_transmitter->last_packet = furi_hal_rtc_get_timestamp();
 
             // Elegant solution, the backlight is only on when there is continuous communication
@@ -33,6 +32,11 @@ static uint16_t bt_serial_callback(SerialServiceEvent event, void *context)
 
 void bt_transmitter_start(BtTransmitter *bt_transmitter)
 {
+    if (bt_transmitter->bt_state == BtStateWaiting) {
+        FURI_LOG_D(TAG, "Bluetooth is already started");
+        return;
+    }
+
     bt_disconnect(bt_transmitter->bt);
     // Wait 2nd core to update nvm storage
     furi_delay_ms(200);
@@ -48,44 +52,84 @@ void bt_transmitter_start(BtTransmitter *bt_transmitter)
 
     furi_check(bt_transmitter->ble_serial_profile);
 
-    ble_profile_serial_set_event_callback
-        (bt_transmitter->ble_serial_profile, BT_SERIAL_BUFFER_SIZE,
-         bt_serial_callback, bt_transmitter);
+    ble_profile_serial_set_event_callback(bt_transmitter->
+                                          ble_serial_profile,
+                                          BT_SERIAL_BUFFER_SIZE,
+                                          bt_serial_callback,
+                                          bt_transmitter);
     furi_hal_bt_start_advertising();
 
     bt_transmitter->bt_state = BtStateWaiting;
     FURI_LOG_D(TAG, "Bluetooth is active!");
+}
 
+/**
+ * @brief Send string by Bluetooth
+ */
+static bool
+bt_transmitter_send_str(BtTransmitter *bt_transmitter, const char *msg,
+                        uint16_t size)
+{
+    furi_assert(bt_transmitter);
+    furi_assert(msg);
+    furi_assert(size);
 
-    // Main loop
-    InputEvent event;
-    while (true) {
-        if (furi_message_queue_get(bt_transmitter->event_queue, &event, 1)
-            == FuriStatusOk) {
-            if (event.type == InputTypeShort && event.key == InputKeyBack)
-                break;
-        }
+    FURI_LOG_D("bt_transmitter_send_str", "Send data: %s", msg);
+    bool res =
+        ble_profile_serial_tx(bt_transmitter->ble_serial_profile,
+                              (uint8_t *) msg, size);
+    FURI_LOG_D("bt_transmitter_send_str", "%s", res ? "OK" : "Fail");
 
-        if (bt_transmitter->bt_state == BtStateRecieving &&
-            (furi_hal_rtc_get_timestamp() - bt_transmitter->last_packet >
-             5))
-            bt_transmitter->bt_state = BtStateLost;
+    return res;
+}
 
-        char *text = "Hello World!";
-
-        bool res =
-            ble_profile_serial_tx(bt_transmitter->ble_serial_profile,
-                                  (uint8_t *) text, sizeof(text));
-        FURI_LOG_D(TAG, "Send data: %s", res ? "OK" : "Fail");
-        furi_delay_ms(1000);
+static bool is_data_ready(BtTransmitter *bt_transmitter)
+{
+    furi_assert(bt_transmitter);
+    if (strlen(bt_transmitter->data.str_data) == 0) {
+        FURI_LOG_D(TAG, "No str_data to send");
+        return false;
     }
+
+    return true;
+}
+
+static void reset_data(BtTransmitter *bt_transmitter)
+{
+    memset(bt_transmitter->data.str_data, 0,
+           sizeof(bt_transmitter->data.str_data));
+}
+
+bool bt_transmitter_send(BtTransmitter *bt_transmitter)
+{
+    if (bt_transmitter->bt_state != BtStateWaiting) {
+        FURI_LOG_D(TAG, "Bluetooth is not ready");
+        return false;
+    }
+
+    if (!is_data_ready(bt_transmitter)) {
+        return false;
+    }
+
+    bool res = false;
+    bt_transmitter->bt_state = BtStateSending;
+    res |=
+        bt_transmitter_send_str(bt_transmitter,
+                                bt_transmitter->data.str_data,
+                                strlen(bt_transmitter->data.str_data));
+
+    reset_data(bt_transmitter);
+    bt_transmitter->bt_state = BtStateWaiting;
+
+    return res;
 }
 
 void bt_transmitter_stop(BtTransmitter *bt_transmitter)
 {
     furi_hal_bt_stop_advertising();
-    ble_profile_serial_set_event_callback
-        (bt_transmitter->ble_serial_profile, 0, NULL, NULL);
+    ble_profile_serial_set_event_callback(bt_transmitter->
+                                          ble_serial_profile, 0, NULL,
+                                          NULL);
 
     bt_disconnect(bt_transmitter->bt);
 
@@ -121,7 +165,6 @@ void bt_transmitter_free(BtTransmitter *bt_transmitter)
     furi_record_close(RECORD_BT);
     free(bt_transmitter);
 }
-
 
 void bt_transmitter_set_state_manager(BtTransmitter *bt_transmitter,
                                       LoraStateManager *state_manager)

--- a/applications_user/lora/bt_transmitter.c
+++ b/applications_user/lora/bt_transmitter.c
@@ -1,6 +1,17 @@
 
 #include "bt_transmitter.h"
 
+// -- PREPARE DATA TO BE SENT FUNCTIONS -----------------------------------------------
+void prepare_bt_data_str(BtTransmitter *bt_transmitter, const char *data)
+{
+    if (sizeof(data) > sizeof(bt_transmitter->data.str_data)) {
+        FURI_LOG_W("lora_receiver_decode_msg_response", "Data too long");
+    }
+    strncpy(bt_transmitter->data.str_data,
+            data, sizeof(bt_transmitter->data.str_data));
+}
+
+
 static uint16_t bt_serial_callback(SerialServiceEvent event, void *context)
 {
     furi_assert(context);
@@ -52,11 +63,9 @@ void bt_transmitter_start(BtTransmitter *bt_transmitter)
 
     furi_check(bt_transmitter->ble_serial_profile);
 
-    ble_profile_serial_set_event_callback(bt_transmitter->
-                                          ble_serial_profile,
-                                          BT_SERIAL_BUFFER_SIZE,
-                                          bt_serial_callback,
-                                          bt_transmitter);
+    ble_profile_serial_set_event_callback
+        (bt_transmitter->ble_serial_profile, BT_SERIAL_BUFFER_SIZE,
+         bt_serial_callback, bt_transmitter);
     furi_hal_bt_start_advertising();
 
     bt_transmitter->bt_state = BtStateWaiting;
@@ -75,9 +84,8 @@ bt_transmitter_send_str(BtTransmitter *bt_transmitter, const char *msg,
     furi_assert(size);
 
     FURI_LOG_D("bt_transmitter_send_str", "Send data: %s", msg);
-    bool res =
-        ble_profile_serial_tx(bt_transmitter->ble_serial_profile,
-                              (uint8_t *) msg, size);
+    bool res = ble_profile_serial_tx(bt_transmitter->ble_serial_profile,
+                                     (uint8_t *) msg, size);
     FURI_LOG_D("bt_transmitter_send_str", "%s", res ? "OK" : "Fail");
 
     return res;
@@ -127,9 +135,8 @@ bool bt_transmitter_send(BtTransmitter *bt_transmitter)
 void bt_transmitter_stop(BtTransmitter *bt_transmitter)
 {
     furi_hal_bt_stop_advertising();
-    ble_profile_serial_set_event_callback(bt_transmitter->
-                                          ble_serial_profile, 0, NULL,
-                                          NULL);
+    ble_profile_serial_set_event_callback
+        (bt_transmitter->ble_serial_profile, 0, NULL, NULL);
 
     bt_disconnect(bt_transmitter->bt);
 

--- a/applications_user/lora/bt_transmitter.c
+++ b/applications_user/lora/bt_transmitter.c
@@ -1,0 +1,130 @@
+
+#include "bt_transmitter.h"
+
+
+static uint16_t bt_serial_callback(SerialServiceEvent event, void *context)
+{
+    furi_assert(context);
+    BtTransmitter *bt_transmitter = context;
+
+    if (event.event == SerialServiceEventTypeDataReceived) {
+        FURI_LOG_D(TAG,
+                   "SerialServiceEventTypeDataReceived. Size: %u/%u. Data: %s",
+                   event.data.size,
+                   sizeof(DataStruct), (char *) event.data.buffer);
+
+        if (event.data.size == sizeof(DataStruct)) {
+            memcpy(&bt_transmitter->data, event.data.buffer,
+                   sizeof(DataStruct));
+            bt_transmitter->bt_state = BtStateRecieving;
+            bt_transmitter->last_packet = furi_hal_rtc_get_timestamp();
+
+            // Elegant solution, the backlight is only on when there is continuous communication
+            notification_message(bt_transmitter->notification,
+                                 &sequence_display_backlight_on);
+
+            notification_message(bt_transmitter->notification,
+                                 &sequence_blink_blue_10);
+        }
+    }
+
+    return 0;
+}
+
+void bt_transmitter_start(BtTransmitter *bt_transmitter)
+{
+    bt_disconnect(bt_transmitter->bt);
+    // Wait 2nd core to update nvm storage
+    furi_delay_ms(200);
+    bt_keys_storage_set_storage_path(bt_transmitter->bt,
+                                     APP_DATA_PATH(".bt_serial.keys"));
+
+    BleProfileSerialParams params = {
+        .device_name_prefix = "Lora",
+        .mac_xor = 0x0002,
+    };
+    bt_transmitter->ble_serial_profile =
+        bt_profile_start(bt_transmitter->bt, ble_profile_serial, &params);
+
+    furi_check(bt_transmitter->ble_serial_profile);
+
+    ble_profile_serial_set_event_callback(bt_transmitter->
+                                          ble_serial_profile,
+                                          BT_SERIAL_BUFFER_SIZE,
+                                          bt_serial_callback,
+                                          bt_transmitter);
+    furi_hal_bt_start_advertising();
+
+    bt_transmitter->bt_state = BtStateWaiting;
+    FURI_LOG_D(TAG, "Bluetooth is active!");
+
+
+    // Main loop
+    InputEvent event;
+    while (true) {
+        if (furi_message_queue_get(bt_transmitter->event_queue, &event, 1)
+            == FuriStatusOk) {
+            if (event.type == InputTypeShort && event.key == InputKeyBack)
+                break;
+        }
+
+        if (bt_transmitter->bt_state == BtStateRecieving &&
+            (furi_hal_rtc_get_timestamp() - bt_transmitter->last_packet >
+             5))
+            bt_transmitter->bt_state = BtStateLost;
+
+        char *text = "Hello World!";
+
+        bool res =
+            ble_profile_serial_tx(bt_transmitter->ble_serial_profile,
+                                  (uint8_t *) text, sizeof(text));
+        FURI_LOG_D(TAG, "Send data: %s", res ? "OK" : "Fail");
+        furi_delay_ms(1000);
+    }
+}
+
+void bt_transmitter_stop(BtTransmitter *bt_transmitter)
+{
+    ble_profile_serial_set_event_callback(bt_transmitter->
+                                          ble_serial_profile, 0, NULL,
+                                          NULL);
+
+    bt_disconnect(bt_transmitter->bt);
+
+    // Wait 2nd core to update nvm storage
+    furi_delay_ms(200);
+
+    bt_keys_storage_set_default_path(bt_transmitter->bt);
+
+    furi_check(bt_profile_restore_default(bt_transmitter->bt));
+}
+
+BtTransmitter *bt_transmitter_alloc(void)
+{
+    BtTransmitter *bt_transmitter = malloc(sizeof(BtTransmitter));
+    bt_transmitter->event_queue =
+        furi_message_queue_alloc(8, sizeof(InputEvent));
+    bt_transmitter->notification = furi_record_open(RECORD_NOTIFICATION);
+    bt_transmitter->bt = furi_record_open(RECORD_BT);
+
+    return bt_transmitter;
+}
+
+void bt_transmitter_free(BtTransmitter *bt_transmitter)
+{
+    bt_transmitter_stop(bt_transmitter);
+
+    furi_message_queue_free(bt_transmitter->event_queue);
+    furi_record_close(RECORD_NOTIFICATION);
+    furi_record_close(RECORD_BT);
+    free(bt_transmitter);
+}
+
+
+void bt_transmitter_set_state_manager(BtTransmitter *bt_transmitter,
+                                      LoraStateManager *state_manager)
+{
+    furi_assert(bt_transmitter);
+    furi_assert(state_manager);
+    bt_transmitter->state_manager = state_manager;
+}

--- a/applications_user/lora/bt_transmitter.h
+++ b/applications_user/lora/bt_transmitter.h
@@ -78,3 +78,13 @@ void bt_transmitter_start(BtTransmitter * bt_transmitter);
  * @brief Send by Bluetooth all data in its field data if ready
  */
 bool bt_transmitter_send(BtTransmitter * bt_transmitter);
+
+
+// -- PREPARE DATA TO BE SENT FUNCTIONS -----------------------------------------------
+
+/**
+ * @brief Set the str_data field of the DataStruct in the BtTransmitter instance
+ * @param bt_transmitter Pointer to the BtTransmitter instance.
+ * @param data String to be sent.
+ */
+void prepare_bt_data_str(BtTransmitter * bt_transmitter, const char *data);

--- a/applications_user/lora/bt_transmitter.h
+++ b/applications_user/lora/bt_transmitter.h
@@ -12,9 +12,9 @@
 #include <storage/storage.h>
 #include "lora_state_manager.h"
 
-
 #define TAG                   "BTTransmitter"
 #define BT_SERIAL_BUFFER_SIZE 128
+#define MAX_DATA_SIZE         (1 << 8) // 256 bytes
 
 #define SCREEN_HEIGHT 64
 #define LINE_HEIGHT   11
@@ -26,21 +26,15 @@ typedef enum {
     BtStateChecking,
     BtStateInactive,
     BtStateWaiting,
-    BtStateRecieving,
+    BtStateReceiving,
+    BtStateSending,
     BtStateNoData,
     BtStateLost
 } BtState;
 
 #pragma pack(push, 1)
 typedef struct {
-    uint8_t cpu_usage;
-    uint16_t ram_max;
-    uint8_t ram_usage;
-    char ram_unit[4];
-    uint8_t gpu_usage;
-    uint16_t vram_max;
-    uint8_t vram_usage;
-    char vram_unit[4];
+    char str_data[MAX_DATA_SIZE];
 } DataStruct;
 #pragma pack(pop)
 
@@ -79,3 +73,8 @@ void bt_transmitter_set_state_manager(BtTransmitter * bt_transmitter,
  * @brief Start the Bluetooth transmitter.
  */
 void bt_transmitter_start(BtTransmitter * bt_transmitter);
+
+/**
+ * @brief Send by Bluetooth all data in its field data if ready
+ */
+bool bt_transmitter_send(BtTransmitter * bt_transmitter);

--- a/applications_user/lora/bt_transmitter.h
+++ b/applications_user/lora/bt_transmitter.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <furi.h>
+#include <furi_hal.h>
+#include <furi_hal_bt.h>
+#include "helpers/ble_serial.h"
+#include <bt/bt_service/bt.h>
+#include <gui/gui.h>
+#include <gui/elements.h>
+#include <notification/notification_messages.h>
+#include <input/input.h>
+#include <storage/storage.h>
+#include "lora_state_manager.h"
+
+
+#define TAG                   "BTTransmitter"
+#define BT_SERIAL_BUFFER_SIZE 128
+
+#define SCREEN_HEIGHT 64
+#define LINE_HEIGHT   11
+
+#define BAR_X     30
+#define BAR_WIDTH 97
+
+typedef enum {
+    BtStateChecking,
+    BtStateInactive,
+    BtStateWaiting,
+    BtStateRecieving,
+    BtStateNoData,
+    BtStateLost
+} BtState;
+
+#pragma pack(push, 1)
+typedef struct {
+    uint8_t cpu_usage;
+    uint16_t ram_max;
+    uint8_t ram_usage;
+    char ram_unit[4];
+    uint8_t gpu_usage;
+    uint16_t vram_max;
+    uint8_t vram_usage;
+    char vram_unit[4];
+} DataStruct;
+#pragma pack(pop)
+
+typedef struct {
+    Bt *bt;
+    FuriMutex *app_mutex;
+    FuriMessageQueue *event_queue;
+    NotificationApp *notification;
+    FuriHalBleProfileBase *ble_serial_profile;
+
+    BtState bt_state;
+    DataStruct data;
+    uint8_t lines_count;
+    uint32_t last_packet;
+    LoraStateManager *state_manager;
+
+} BtTransmitter;
+
+/**
+ * @brief Allocate and initialize a BtTransmitter instance.
+ */
+BtTransmitter *bt_transmitter_alloc(void);
+
+/**
+ * @brief Free the BtTransmitter instance.
+ */
+void bt_transmitter_free(BtTransmitter * bt_transmitter);
+
+/**
+ * @brief Set the state manager for the BtTransmitter instance.
+ */
+void bt_transmitter_set_state_manager(BtTransmitter * bt_transmitter,
+                                      LoraStateManager * state_manager);
+
+/**
+ * @brief Start the Bluetooth transmitter.
+ */
+void bt_transmitter_start(BtTransmitter * bt_transmitter);

--- a/applications_user/lora/helpers/ble_serial.c
+++ b/applications_user/lora/helpers/ble_serial.c
@@ -1,0 +1,135 @@
+/*
+ * This code is based on the Willy-JL's (https://github.com/Willy-JL) BLE fix.
+ * 
+ * Thank you to Willy-JL for providing this code and making it available under the https://github.com/Flipper-XFW/Xtreme-Apps repository.
+ * Your contribution has been invaluable for this project.
+ * 
+ * Based on <targets/f7/ble_glue/profiles/serial_profile.c>
+ * and on <lib/ble_profile/extra_profiles/hid_profile.c>
+ */
+
+#include "ble_serial.h"
+
+#include <gap.h>
+#include <furi_ble/profile_interface.h>
+#include <services/serial_service.h>
+#include <furi.h>
+#include <ble/core/ble_defs.h>
+
+typedef struct {
+    FuriHalBleProfileBase base;
+
+    BleServiceSerial *serial_svc;
+} BleProfileSerial;
+_Static_assert(offsetof(BleProfileSerial, base) == 0, "Wrong layout");
+
+static FuriHalBleProfileBase
+    *ble_profile_serial_start(FuriHalBleProfileParams profile_params)
+{
+    UNUSED(profile_params);
+
+    BleProfileSerial *profile = malloc(sizeof(BleProfileSerial));
+
+    profile->base.config = ble_profile_serial;
+
+    profile->serial_svc = ble_svc_serial_start();
+
+    return &profile->base;
+}
+
+static void ble_profile_serial_stop(FuriHalBleProfileBase *profile)
+{
+    furi_check(profile);
+    furi_check(profile->config == ble_profile_serial);
+
+    BleProfileSerial *serial_profile = (BleProfileSerial *) profile;
+    ble_svc_serial_stop(serial_profile->serial_svc);
+}
+
+ // AN5289: 4.7, in order to use flash controller interval must be at least 25ms + advertisement, which is 30 ms
+ // Since we don't use flash controller anymore interval can be lowered to 7.5ms
+#define CONNECTION_INTERVAL_MIN (0x06)
+ // Up to 45 ms
+#define CONNECTION_INTERVAL_MAX (0x24)
+
+static const GapConfig serial_template_config = {
+    .adv_service_uuid = 0x3080,
+    .appearance_char = 0x8600,
+    .bonding_mode = true,
+    .pairing_method = GapPairingPinCodeShow,
+    .conn_param = {
+                   .conn_int_min = CONNECTION_INTERVAL_MIN,
+                   .conn_int_max = CONNECTION_INTERVAL_MAX,
+                   .slave_latency = 0,
+                   .supervisor_timeout = 0,
+                    }
+};
+
+static void
+ble_profile_serial_get_config(GapConfig *config,
+                              FuriHalBleProfileParams profile_params)
+{
+    BleProfileSerialParams *serial_profile_params = profile_params;
+
+    furi_check(config);
+    memcpy(config, &serial_template_config, sizeof(GapConfig));
+    // Set mac address
+    memcpy(config->mac_address, furi_hal_version_get_ble_mac(),
+           sizeof(config->mac_address));
+
+    // Change MAC address for Serial profile
+    config->mac_address[2]++;
+    if (serial_profile_params) {
+        config->mac_address[0] ^= serial_profile_params->mac_xor;
+        config->mac_address[1] ^= serial_profile_params->mac_xor >> 8;
+    }
+    // Set advertise name
+    const char *clicker_str = "Serial";
+    if (serial_profile_params && serial_profile_params->device_name_prefix) {
+        clicker_str = serial_profile_params->device_name_prefix;
+    }
+    snprintf(config->adv_name,
+             sizeof(config->adv_name),
+             "%c%s %s",
+             furi_hal_version_get_ble_local_device_name_ptr()[0],
+             clicker_str, furi_hal_version_get_name_ptr());
+
+    config->adv_service_uuid = UUID_TYPE_16;
+    config->adv_service_uuid |= furi_hal_version_get_hw_color();
+}
+
+static const FuriHalBleProfileTemplate profile_callbacks = {
+    .start = ble_profile_serial_start,
+    .stop = ble_profile_serial_stop,
+    .get_gap_config = ble_profile_serial_get_config,
+};
+
+const FuriHalBleProfileTemplate *const ble_profile_serial =
+    &profile_callbacks;
+
+void ble_profile_serial_set_event_callback(FuriHalBleProfileBase *profile,
+                                           uint16_t buff_size,
+                                           FuriHalBtSerialCallback
+                                           callback, void *context)
+{
+    furi_check(profile && (profile->config == ble_profile_serial));
+
+    BleProfileSerial *serial_profile = (BleProfileSerial *) profile;
+    ble_svc_serial_set_callbacks(serial_profile->serial_svc, buff_size,
+                                 callback, context);
+}
+
+bool ble_profile_serial_tx(FuriHalBleProfileBase *profile, uint8_t *data,
+                           uint16_t size)
+{
+    furi_check(profile && (profile->config == ble_profile_serial));
+
+    BleProfileSerial *serial_profile = (BleProfileSerial *) profile;
+
+    if (size > BLE_PROFILE_SERIAL_PACKET_SIZE_MAX) {
+        return false;
+    }
+
+    return ble_svc_serial_update_tx(serial_profile->serial_svc, data,
+                                    size);
+}

--- a/applications_user/lora/helpers/ble_serial.h
+++ b/applications_user/lora/helpers/ble_serial.h
@@ -1,0 +1,65 @@
+/*
+ * This code is based on the Willy-JL's (https://github.com/Willy-JL) BLE fix.
+ * 
+ * Thank you to Willy-JL for providing this code and making it available under the https://github.com/Flipper-XFW/Xtreme-Apps repository.
+ * Your contribution has been invaluable for this project.
+ * 
+ * Based on <targets/f7/ble_glue/profiles/serial_profile.h>
+ * and on <lib/ble_profile/extra_profiles/hid_profile.h>
+ */
+
+#pragma once
+
+#include <furi_ble/profile_interface.h>
+
+#include <services/serial_service.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ /** 
+  * Optional arguments to pass along with profile template as 
+  * FuriHalBleProfileParams for tuning profile behavior 
+  **/
+    typedef struct {
+        const char *device_name_prefix;
+                                     /**< Prefix for device name. Length must be less than 8 */
+        uint16_t mac_xor;
+                       /**< XOR mask for device address, for uniqueness */
+    } BleProfileSerialParams;
+
+#define BLE_PROFILE_SERIAL_PACKET_SIZE_MAX BLE_SVC_SERIAL_DATA_LEN_MAX
+
+ /** Serial service callback type */
+    typedef SerialServiceEventCallback FuriHalBtSerialCallback;
+
+ /** Serial profile descriptor */
+    extern const FuriHalBleProfileTemplate *const ble_profile_serial;
+
+ /** Send data through BLE
+  *
+  * @param profile       Profile instance
+  * @param data          data buffer
+  * @param size          data buffer size
+  *
+  * @return      true on success
+  */
+    bool ble_profile_serial_tx(FuriHalBleProfileBase * profile,
+                               uint8_t * data, uint16_t size);
+
+ /** Set Serial service events callback
+  *
+  * @param profile       Profile instance
+  * @param buffer_size   Applicaition buffer size
+  * @param calback       FuriHalBtSerialCallback instance
+  * @param context       pointer to context
+  */
+    void ble_profile_serial_set_event_callback(FuriHalBleProfileBase *
+                                               profile, uint16_t buff_size,
+                                               FuriHalBtSerialCallback
+                                               callback, void *context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications_user/lora/lora_app.c
+++ b/applications_user/lora/lora_app.c
@@ -23,14 +23,10 @@ static LoraApp *lora_app_alloc()
 {
     LoraApp *app = malloc(sizeof(LoraApp));
 
-    // Initialize the GUI. Create a view dispatcher and attach it to the GUI.
-    // Create a submenu, add default entries and add the submenu to the view
-    // dispatcher. Set the submenu as the current view.
     app->gui = furi_record_open(RECORD_GUI);
     app->scene_manager = scene_manager_alloc(&lora_scene_handlers, app);
 
     app->view_dispatcher = view_dispatcher_alloc();
-    view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_custom_event_callback(app->view_dispatcher,
                                               lora_app_custom_event_callback);
@@ -48,9 +44,10 @@ static LoraApp *lora_app_alloc()
     view_dispatcher_add_view(app->view_dispatcher, LoraAppReceiverCfgView,
                              variable_item_list_get_view
                              (app->var_item_list));
+    // Allocate a Bluetooth transmitter
+    app->bt_transmitter = bt_transmitter_alloc();
 
-
-    // Allocate a transmitter object
+    // Allocate a serial transmitter object
     UartHelper *uart_helper = uart_helper_alloc(DEVICE_BAUDRATE, app);
     LoraTransmitterMethod send_method =
         (LoraTransmitterMethod) uart_helper_send;
@@ -74,6 +71,8 @@ static LoraApp *lora_app_alloc()
     lora_receiver_set_state_manager(app->receiver, app->state_manager);
     lora_transmitter_set_state_manager(app->transmitter,
                                        app->state_manager);
+    bt_transmitter_set_state_manager(app->bt_transmitter,
+                                     app->state_manager);
 
 
 
@@ -104,8 +103,13 @@ static void lora_app_free(LoraApp *app)
     view_dispatcher_free(app->view_dispatcher);
     scene_manager_free(app->scene_manager);
     submenu_free(app->submenu);
+    lora_state_manager_free(app->state_manager);
+
+    // Free all objects
+    bt_transmitter_free(app->bt_transmitter);
     lora_receiver_free(app->receiver);
     lora_transmitter_free(app->transmitter);
+
     furi_record_close(RECORD_GUI);
 
     free(app);

--- a/applications_user/lora/lora_app.h
+++ b/applications_user/lora/lora_app.h
@@ -15,6 +15,7 @@
 #include "uart_helper.h"
 #include "lora_receiver.h"
 #include "lora_transmitter.h"
+#include "bt_transmitter.h"
 #include "lora_custom_event.h"
 
 #define DEVICE_BAUDRATE  9600
@@ -44,6 +45,7 @@ typedef struct {
     uint32_t index;
     LoraReceiver *receiver;
     LoraTransmitter *transmitter;
+    BtTransmitter *bt_transmitter;
     LoraState current_state;
 } LoraApp;
 

--- a/applications_user/lora/lora_receiver.c
+++ b/applications_user/lora/lora_receiver.c
@@ -198,12 +198,10 @@ void lora_receiver_decode_msg_response(void *context, FuriString *line)
                     // Copy the string data to be sent by Bluetooth
                     if (type_packet == LoraPacketRxPacket){
                         hex_to_string(model->msg_response.data, model->msg_response.decoded_data);
-                        strncpy(app->bt_transmitter->data.str_data,
-                               model->msg_response.decoded_data,
-                               sizeof(model->msg_response.decoded_data));
+                        prepare_bt_data_str(app->bt_transmitter, model->msg_response.decoded_data);
                     }
                     
-                    // Can add more data to be sent by Bluetooth here
+                    // Can call more prepare bluetooth data functions here depending of the type of packet
 
                     }, true);
 /* *INDENT-ON* */

--- a/applications_user/lora/lora_receiver.c
+++ b/applications_user/lora/lora_receiver.c
@@ -163,18 +163,18 @@ static int parse_msg_response(FuriString *line,
     }
     // Try each parser until one succeeds
     if (parse_pending(line, msg_response) == 0)
-        return 0;
+        return LoraPacketFpending;
     if (parse_link_info(line, msg_response) == 0)
-        return 0;
+        return LoraPacketLinkInfo;
     if (parse_rxwin_info(line, msg_response) == 0)
-        return 0;
+        return LoraPacketRxwinInfo;
     if (parse_ack(line, msg_response) == 0)
-        return 0;
+        return LoraPacketAck;
     if (parse_multicast(line, msg_response) == 0)
-        return 0;
+        return LoraPacketMulticast;
     if (parse_rx_packet(line, msg_response) == 0) {
         if (parse_port(line, msg_response) == 0) { // Port and Data are in the same line in MSG
-            return 0;
+            return LoraPacketRxPacket;
         }
     }
     // If none matched, fallback to RX packet
@@ -186,18 +186,28 @@ static int parse_msg_response(FuriString *line,
  * @param receiver Pointer to the LoraReceiver object.
  * @param data Pointer to the data to be set.
  */
-void lora_receiver_decode_msg_response(LoraReceiver *receiver,
-                                       FuriString *line)
+void lora_receiver_decode_msg_response(void *context, FuriString *line)
 {
-    furi_assert(receiver);
+    LoraApp *app = context;
+    furi_assert(app);
     furi_assert(line);
 /* *INDENT-OFF* */
-    with_view_model(receiver->view, LoraReceiverModel * model, {
-                    parse_msg_response(line, &model->msg_response);
-                    hex_to_string(model->msg_response.data,
-                                  model->msg_response.decoded_data);
+    with_view_model(app->receiver->view, LoraReceiverModel * model, {
+                    LoraPacketType type_packet = parse_msg_response(line, &model->msg_response);
+    
+                    // Copy the string data to be sent by Bluetooth
+                    if (type_packet == LoraPacketRxPacket){
+                        hex_to_string(model->msg_response.data, model->msg_response.decoded_data);
+                        strncpy(app->bt_transmitter->data.str_data,
+                               model->msg_response.decoded_data,
+                               sizeof(model->msg_response.decoded_data));
+                    }
+                    
+                    // Can add more data to be sent by Bluetooth here
+
                     }, true);
 /* *INDENT-ON* */
+
 }
 
 
@@ -359,7 +369,9 @@ void lora_receiver_rx_response_callback(FuriString *line, void *context)
     FURI_LOG_D("lora_receiver_rx_response_callback", "%s",
                furi_string_get_cstr(line));
     LoraApp *app = context;
-    lora_receiver_decode_msg_response(app->receiver, line);
+    lora_receiver_decode_msg_response(app, line);
+
+    bt_transmitter_send(app->bt_transmitter);
 }
 
 void lora_receiver_default_response_callback(FuriString *line,

--- a/applications_user/lora/lora_receiver.h
+++ b/applications_user/lora/lora_receiver.h
@@ -49,14 +49,11 @@ extern "C" {
                                              uint32_t size);
 
 /**
- * @brief Parse and decode the raw data received from the LoRa module. Stores the result in
- * in the decoded_data field of the msg_response model.
+ * @brief Set the data message response and update the view.
  * @param receiver Pointer to the LoraReceiver object.
- * @param line Pointer to the FuriString object containing the raw data.
- * 
- * @return void
+ * @param line string to be decoded.
  */
-    void lora_receiver_decode_msg_response(LoraReceiver * receiver,
+    void lora_receiver_decode_msg_response(void *context,
                                            FuriString * line);
 
 /**

--- a/applications_user/lora/lora_receiver_i.h
+++ b/applications_user/lora/lora_receiver_i.h
@@ -3,6 +3,7 @@
 #include "lora_receiver.h"
 #include "lora_config.h"
 #include "lora_custom_event.h"
+#include "bt_transmitter.h"
 #include <furi.h>
 
 #define MAX_DATA_SIZE (1 << 8)  // 256 bytes

--- a/applications_user/lora/lora_receiver_i.h
+++ b/applications_user/lora/lora_receiver_i.h
@@ -56,6 +56,16 @@ struct LoraReceiver {
     LoraStateManager *state_manager;
 };
 
+typedef enum {
+    LoraPacketFpending,         // +{MSG, CMSG}: FPENDING
+    LoraPacketLinkInfo,         // +{MSG, CMSG}: Link <margin>,<gateway_count>
+    LoraPacketRxwinInfo,        // +{MSG, CMSG, TEST}: RXWIN<rx_window>, RSSI <rssi>, SNR <snr>
+    LoraPacketAck,              // +{MSG, CMSG}: ACK Received
+    LoraPacketMulticast,        // +{MSG, CMSG}: MULTICAST
+    LoraPacketRxPacket,         // +{MSG, TEST} PORT: <port>; RX: "<hex data>"
+} LoraPacketType;
+
+
 // DEBUG MACRO
 #define DEBUG_LORA_MSG_RESPONSE(lora_receiver)                                                   \
     FURI_LOG_D("DebugMsgResponse", "LoRaMsgResponseModel Debug:");                               \

--- a/applications_user/lora/scenes/lora_scene_start.c
+++ b/applications_user/lora/scenes/lora_scene_start.c
@@ -25,6 +25,10 @@ static void lora_submenu_item_callback(void *context, uint32_t index)
         lora_transmitter_send_cmsg(app->transmitter, "Hello World");
         // scene_manager_next_scene(app->scene_manager, LoraSceneLorawan);
         break;
+    case 3:
+        bt_transmitter_start(app->bt_transmitter);
+        break;
+
     default:
         break;
     }
@@ -46,6 +50,8 @@ static void lora_submenu_add_default_entries(Submenu *submenu,
                      lora_submenu_item_callback, context);
     submenu_add_item(submenu, "Send Msg", 2, lora_submenu_item_callback,
                      context);
+    submenu_add_item(submenu, "Blutooth", 3,
+                     lora_submenu_item_callback, context);
 
     app->index = 3;
 }

--- a/applications_user/lora/scenes/lora_scene_start.c
+++ b/applications_user/lora/scenes/lora_scene_start.c
@@ -25,9 +25,6 @@ static void lora_submenu_item_callback(void *context, uint32_t index)
         lora_transmitter_send_cmsg(app->transmitter, "Hello World");
         // scene_manager_next_scene(app->scene_manager, LoraSceneLorawan);
         break;
-    case 3:
-        bt_transmitter_start(app->bt_transmitter);
-        break;
 
     default:
         break;
@@ -50,8 +47,6 @@ static void lora_submenu_add_default_entries(Submenu *submenu,
                      lora_submenu_item_callback, context);
     submenu_add_item(submenu, "Send Msg", 2, lora_submenu_item_callback,
                      context);
-    submenu_add_item(submenu, "Blutooth", 3,
-                     lora_submenu_item_callback, context);
 
     app->index = 3;
 }
@@ -59,6 +54,7 @@ static void lora_submenu_add_default_entries(Submenu *submenu,
 void lora_scene_start_on_enter(void *context)
 {
     LoraApp *app = context;
+    bt_transmitter_start(app->bt_transmitter); // Start Bluetooth transmitter
     lora_submenu_add_default_entries(app->submenu, app);
     view_dispatcher_switch_to_view(app->view_dispatcher,
                                    LoraAppSubMenuView);


### PR DESCRIPTION
# What's new

- Added a Bluetooth transmitter module (`bt_transmitter.c`) and a BLE serial helper (`ble_serial`), inspired by [this project](https://github.com/TheSainEyereg/flipper-pc-monitor).
- The LoRa App now automatically starts a Bluetooth transmitter (`bt_transmitter`) to establish a connection with the mobile app.
- The Bluetooth transmitter forwards RX messages received by the LoRa receiver to the mobile app.
- Refactored the `parse_msg_response` function in `lora_receiver.c` to determine when to send Bluetooth packets (currently, lora packets with only SNR and RSSI info are not forwarded).

